### PR TITLE
feat: dynamic max ingredient bonuses instead of static ones

### DIFF
--- a/common/src/domain/constants.ts
+++ b/common/src/domain/constants.ts
@@ -4,8 +4,6 @@ export const TASTY_CHANCE_S_CAP = 0.7;
 
 // recipe
 export const MAX_RECIPE_LEVEL = 60;
-// TODO: rework max recipe bonus to be per ingredient, slowpoke tail for example cant reach 48%
-export const MAX_RECIPE_BONUS = 61;
 
 // ingredient
 export const MAX_INGREDIENT_INVENTORY = 700;

--- a/common/src/domain/ingredient/ingredient.test.ts
+++ b/common/src/domain/ingredient/ingredient.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import type { Ingredient } from './ingredient';
 import * as IngredientsModule from './ingredients';
+import { createIngredient } from './ingredients';
+
+describe('createIngredient', () => {
+  it('should create an ingredient', () => {
+    const ingredient = createIngredient({
+      name: 'Seaweed',
+      value: 10,
+      taxedValue: 15,
+      longName: 'Squirmy Seaweed'
+    });
+
+    expect(ingredient.name).toBe('Seaweed');
+    expect(ingredient.value).toBe(10);
+    expect(ingredient.taxedValue).toBe(15);
+    expect(ingredient.longName).toBe('Squirmy Seaweed');
+  });
+});
 
 describe('INGREDIENTS array', () => {
   it('should include all dynamically defined ingredients in the INGREDIENTS array', () => {

--- a/common/src/domain/ingredient/ingredients.ts
+++ b/common/src/domain/ingredient/ingredients.ts
@@ -1,123 +1,123 @@
 import type { Ingredient } from './ingredient';
 
-export const FANCY_APPLE: Ingredient = {
+export const FANCY_APPLE: Ingredient = createIngredient({
   name: 'Apple',
   value: 90,
   taxedValue: 23.7,
   longName: 'Fancy Apple'
-};
+});
 
-export const MOOMOO_MILK: Ingredient = {
+export const MOOMOO_MILK: Ingredient = createIngredient({
   name: 'Milk',
   value: 98,
   taxedValue: 28.1,
   longName: 'Moomoo Milk'
-};
+});
 
-export const GREENGRASS_SOYBEANS: Ingredient = {
+export const GREENGRASS_SOYBEANS: Ingredient = createIngredient({
   name: 'Soybean',
   value: 100,
   taxedValue: 29.2,
   longName: 'Greengrass Soybeans'
-};
+});
 
-export const HONEY: Ingredient = {
+export const HONEY: Ingredient = createIngredient({
   name: 'Honey',
   value: 101,
   taxedValue: 29.8,
   longName: 'Honey'
-};
+});
 
-export const BEAN_SAUSAGE: Ingredient = {
+export const BEAN_SAUSAGE: Ingredient = createIngredient({
   name: 'Sausage',
   value: 103,
   taxedValue: 31,
   longName: 'Bean Sausage'
-};
+});
 
-export const WARMING_GINGER: Ingredient = {
+export const WARMING_GINGER: Ingredient = createIngredient({
   name: 'Ginger',
   value: 109,
   taxedValue: 34.7,
   longName: 'Warming Ginger'
-};
+});
 
-export const SNOOZY_TOMATO: Ingredient = {
+export const SNOOZY_TOMATO: Ingredient = createIngredient({
   name: 'Tomato',
   value: 110,
   taxedValue: 35.4,
   longName: 'Snoozy Tomato'
-};
+});
 
-export const FANCY_EGG: Ingredient = {
+export const FANCY_EGG: Ingredient = createIngredient({
   name: 'Egg',
   value: 115,
   taxedValue: 38.7,
   longName: 'Fancy Egg'
-};
+});
 
-export const PURE_OIL: Ingredient = {
+export const PURE_OIL: Ingredient = createIngredient({
   name: 'Oil',
   value: 121,
   taxedValue: 42.8,
   longName: 'Pure Oil'
-};
+});
 
-export const SOFT_POTATO: Ingredient = {
+export const SOFT_POTATO: Ingredient = createIngredient({
   name: 'Potato',
   value: 124,
   taxedValue: 45,
   longName: 'Soft Potato'
-};
+});
 
-export const FIERY_HERB: Ingredient = {
+export const FIERY_HERB: Ingredient = createIngredient({
   name: 'Herb',
   value: 130,
   taxedValue: 49.4,
   longName: 'Fiery Herb'
-};
+});
 
-export const GREENGRASS_CORN: Ingredient = {
+export const GREENGRASS_CORN: Ingredient = createIngredient({
   name: 'Corn',
   value: 140,
   taxedValue: 57.3,
   longName: 'Greengrass Corn'
-};
+});
 
-export const SOOTHING_CACAO: Ingredient = {
+export const SOOTHING_CACAO: Ingredient = createIngredient({
   name: 'Cacao',
   value: 151,
   taxedValue: 66.7,
   longName: 'Soothing Cacao'
-};
+});
 
-export const ROUSING_COFFEE: Ingredient = {
+export const ROUSING_COFFEE: Ingredient = createIngredient({
   name: 'Coffee',
   value: 153,
   taxedValue: 68.4,
   longName: 'Rousing Coffee'
-};
+});
 
-export const TASTY_MUSHROOM: Ingredient = {
+export const TASTY_MUSHROOM: Ingredient = createIngredient({
   name: 'Mushroom',
   value: 167,
   taxedValue: 81.5,
   longName: 'Tasty Mushroom'
-};
+});
 
-export const LARGE_LEEK: Ingredient = {
+export const LARGE_LEEK: Ingredient = createIngredient({
   name: 'Leek',
   value: 185,
   taxedValue: 100.1,
   longName: 'Large Leek'
-};
+});
 
-export const SLOWPOKE_TAIL: Ingredient = {
+export const SLOWPOKE_TAIL: Ingredient = createIngredient({
   name: 'Tail',
   value: 342,
   taxedValue: 342,
   longName: 'Slowpoke Tail'
-};
+});
 
 export const INGREDIENTS: Ingredient[] = [
   FANCY_APPLE,
@@ -138,4 +138,20 @@ export const INGREDIENTS: Ingredient[] = [
   LARGE_LEEK,
   SLOWPOKE_TAIL
 ];
+
 export const TOTAL_NUMBER_OF_INGREDIENTS = INGREDIENTS.length;
+
+export function createIngredient(params: {
+  name: string;
+  value: number;
+  taxedValue: number;
+  longName: string;
+}): Ingredient {
+  const { name, value, taxedValue, longName } = params;
+  return {
+    name,
+    value,
+    taxedValue,
+    longName
+  };
+}

--- a/common/src/utils/ingredient-utils/ingredient-utils.test.ts
+++ b/common/src/utils/ingredient-utils/ingredient-utils.test.ts
@@ -6,10 +6,13 @@ import {
   HONEY,
   INGREDIENTS,
   MOOMOO_MILK,
+  ROUSING_COFFEE,
+  SOFT_POTATO,
   SOOTHING_CACAO
 } from '../../domain/ingredient/ingredients';
 import { PINSIR } from '../../domain/pokemon/ingredient-pokemon';
 import type { PokemonWithIngredients } from '../../domain/pokemon/pokemon';
+import { commonMocks } from '../../vitest';
 import {
   calculateAveragePokemonIngredientSet,
   combineSameIngredientsInDrop,
@@ -18,6 +21,7 @@ import {
   getAllIngredientLists,
   getIngredient,
   getIngredientNames,
+  getMaxIngredientBonus,
   includesMagnet,
   ingredientIndex,
   ingredientSetToFloatFlat,
@@ -25,7 +29,8 @@ import {
   prettifyIngredientDrop,
   shortPrettifyIngredientDrop,
   simplifyIngredientSet,
-  unsimplifyIngredientSet
+  unsimplifyIngredientSet,
+  updateMaxIngredientBonus
 } from './ingredient-utils';
 
 describe('getIngredient', () => {
@@ -737,5 +742,46 @@ describe('ingredientIndex', () => {
   });
   it('shall return 2 for 100', () => {
     expect(ingredientIndex(100)).toBe(2);
+  });
+});
+
+const MOCK_SEAWEED = commonMocks.mockIngredient({
+  name: 'Seaweed',
+  value: 101
+});
+
+const mockRecipeList = [
+  commonMocks.recipe({
+    name: 'MOCK_RECIPE_MAX_BONUS_UPDATED',
+    ingredients: [{ amount: 1, ingredient: SOFT_POTATO }],
+    bonus: 70
+  }),
+  commonMocks.recipe({
+    name: 'MOCK_RECIPE_NEWLY_SET_BONUS',
+    ingredients: [
+      { amount: 1, ingredient: MOCK_SEAWEED },
+      { amount: 1, ingredient: ROUSING_COFFEE }
+    ],
+    bonus: 15.77
+  })
+];
+
+describe('updateIngredientBonus', () => {
+  it('should correctly set the bonus for ingredients in recipes', () => {
+    mockRecipeList.forEach((recipe) => {
+      updateMaxIngredientBonus(recipe.ingredients, recipe.bonus);
+    });
+
+    const expectedBonuses = {
+      Potato: 70,
+      Seaweed: 15.77,
+      Coffee: 61, // ingredientBonusCache is populated upon startup
+      Tail: 25, // ingredientBonusCache is populated upon startup
+      Cheese: 0 // default to 0 if not in cache
+    };
+
+    for (const [ingredientName, bonus] of Object.entries(expectedBonuses)) {
+      expect(getMaxIngredientBonus(ingredientName)).toBe(bonus);
+    }
   });
 });

--- a/common/src/utils/ingredient-utils/ingredient-utils.ts
+++ b/common/src/utils/ingredient-utils/ingredient-utils.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../domain/ingredient/ingredient';
 import { INGREDIENTS, TOTAL_NUMBER_OF_INGREDIENTS } from '../../domain/ingredient/ingredients';
 import type { Pokemon } from '../../domain/pokemon/pokemon';
+import '../../prototype/logger';
 import { emptyIngredientInventoryFloat, emptyIngredientInventoryInt } from '../flat-utils';
 import { MathUtils } from '../math-utils/math-utils';
 import { capitalize } from '../string-utils/string-utils';
@@ -14,6 +15,8 @@ import { capitalize } from '../string-utils/string-utils';
 export const ING_ID_LOOKUP: Record<string, number> = Object.fromEntries(
   INGREDIENTS.map((ingredient, index) => [ingredient.name, index])
 );
+
+const ingredientBonusCache = new Map<string, number>();
 
 export function getIngredientName(ingredient: Ingredient): string;
 export function getIngredientName(ingredient: number): string;
@@ -213,4 +216,23 @@ export function calculateAveragePokemonIngredientSet(
   const multiplier = 1 / ingredientsUnlocked;
   const dividedIngredients = Float32Array.from(ingredients, (value) => value * multiplier);
   return dividedIngredients;
+}
+
+export function updateMaxIngredientBonus(ingredientSets: IngredientSet[], bonus: number): void {
+  for (const ingredientSet of ingredientSets) {
+    const ingredientName = ingredientSet.ingredient.name;
+    const currentBonus = ingredientBonusCache.get(ingredientName);
+    if (currentBonus === undefined || currentBonus < bonus) {
+      ingredientBonusCache.set(ingredientName, bonus);
+    }
+  }
+}
+
+export function getMaxIngredientBonus(ingredientName: string): number {
+  const bonus = ingredientBonusCache.get(ingredientName);
+  if (bonus === undefined) {
+    logger.error(`Error: Max bonus for ingredient "${ingredientName}" not found.`);
+    return 0;
+  }
+  return bonus;
 }

--- a/common/src/utils/recipe-utils/recipe-utils.ts
+++ b/common/src/utils/recipe-utils/recipe-utils.ts
@@ -2,7 +2,7 @@ import { MAX_RECIPE_LEVEL } from '../../domain/constants';
 import type { IngredientIndexToIntAmount, IngredientSet } from '../../domain/ingredient';
 import type { Recipe, RecipeFlat, RecipeType } from '../../domain/recipe';
 import { emptyIngredientInventoryFloat } from '../../utils/flat-utils';
-import { ING_ID_LOOKUP } from '../ingredient-utils/ingredient-utils';
+import { ING_ID_LOOKUP, updateMaxIngredientBonus } from '../ingredient-utils/ingredient-utils';
 
 export function createCurry(params: { name: string; ingredients: IngredientSet[]; bonus: number }): Recipe {
   return createRecipe({ ...params, type: 'curry' });
@@ -78,6 +78,7 @@ export function recipeCoverage(recipe: Int16Array, ingredients: IngredientIndexT
 function createRecipe(params: { name: string; ingredients: IngredientSet[]; bonus: number; type: RecipeType }): Recipe {
   const { name, ingredients, bonus, type } = params;
   const nrOfIngredients = ingredients.reduce((sum, cur) => sum + cur.amount, 0);
+  updateMaxIngredientBonus(ingredients, bonus);
   return {
     name,
     value: calculateRecipeValue({ level: 1, ingredients, bonus }),

--- a/frontend/src/components/compare/compare-strength.test.ts
+++ b/frontend/src/components/compare/compare-strength.test.ts
@@ -9,9 +9,9 @@ import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import {
   AVERAGE_WEEKLY_CRIT_MULTIPLIER,
-  MAX_RECIPE_BONUS,
   MAX_RECIPE_LEVEL,
   berryPowerForLevel,
+  getMaxIngredientBonus,
   recipeLevelBonus,
   type MemberProduction
 } from 'sleepapi-common'
@@ -74,11 +74,13 @@ describe('CompareStrength', () => {
 
     // Check ingredient power range
     const highestIngredientValue = Math.floor(
-      (1 + MAX_RECIPE_BONUS / 100) *
-        recipeLevelBonus[MAX_RECIPE_LEVEL] *
+      recipeLevelBonus[MAX_RECIPE_LEVEL] *
         userStore.islandBonus *
         AVERAGE_WEEKLY_CRIT_MULTIPLIER *
-        mockMemberProduction.produceTotal.ingredients.reduce((sum, cur) => sum + cur.amount * cur.ingredient.value, 0)
+        mockMemberProduction.produceTotal.ingredients.reduce((sum, cur) => {
+          const ingredientBonus = 1 + getMaxIngredientBonus(cur.ingredient.name) / 100
+          return sum + cur.amount * ingredientBonus * cur.ingredient.value
+        }, 0)
     )
     expect(wrapper.vm.highestIngredientPower(mockMemberProduction)).toEqual(highestIngredientValue)
 
@@ -139,14 +141,13 @@ describe('CompareStrength', () => {
 
     // Check ingredient power range
     const highestIngredientValue = Math.floor(
-      ((1 + MAX_RECIPE_BONUS / 100) *
-        recipeLevelBonus[MAX_RECIPE_LEVEL] *
+      (recipeLevelBonus[MAX_RECIPE_LEVEL] *
         userStore.islandBonus *
         AVERAGE_WEEKLY_CRIT_MULTIPLIER *
-        mockMemberProduction.produceTotal.ingredients.reduce(
-          (sum, cur) => sum + cur.amount * cur.ingredient.value,
-          0
-        )) /
+        mockMemberProduction.produceTotal.ingredients.reduce((sum, cur) => {
+          const ingredientBonus = 1 + getMaxIngredientBonus(cur.ingredient.name) / 100
+          return sum + cur.amount * ingredientBonus * cur.ingredient.value
+        }, 0)) /
         3
     )
     expect(wrapper.vm.highestIngredientPower(mockMemberProduction)).toEqual(highestIngredientValue)

--- a/frontend/src/components/compare/compare-strength.vue
+++ b/frontend/src/components/compare/compare-strength.vue
@@ -191,11 +191,11 @@ import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useUserStore } from '@/stores/user-store'
 import {
   AVERAGE_WEEKLY_CRIT_MULTIPLIER,
-  MAX_RECIPE_BONUS,
   MAX_RECIPE_LEVEL,
   MathUtils,
   compactNumber,
   defaultZero,
+  getMaxIngredientBonus,
   mainskill,
   recipeLevelBonus,
   type MemberProduction
@@ -356,16 +356,14 @@ export default defineComponent({
       return Math.floor(amount * StrengthService.timeWindowFactor(this.comparisonStore.timeWindow))
     },
     highestIngredientPower(memberProduction: MemberProduction) {
-      const recipeBonus = 1 + MAX_RECIPE_BONUS / 100
       const maxLevelRecipeMultiplier = recipeLevelBonus[MAX_RECIPE_LEVEL]
       const amount =
-        recipeBonus *
         maxLevelRecipeMultiplier *
         this.userStore.islandBonus *
-        memberProduction.produceTotal.ingredients.reduce(
-          (sum, cur) => sum + cur.amount * cur.ingredient.value * AVERAGE_WEEKLY_CRIT_MULTIPLIER,
-          0
-        )
+        memberProduction.produceTotal.ingredients.reduce((sum, cur) => {
+          const ingredientBonus = 1 + getMaxIngredientBonus(cur.ingredient.name) / 100
+          return sum + cur.amount * ingredientBonus * cur.ingredient.value * AVERAGE_WEEKLY_CRIT_MULTIPLIER
+        }, 0)
       return Math.floor(amount * StrengthService.timeWindowFactor(this.comparisonStore.timeWindow))
     },
     setIngredientOptions(option: string) {


### PR DESCRIPTION
Changes:

    Wrapped Ingredients in a createIngredient function
    Created an ingredientBonusCache that's updated when recipes are created
    Updated frontend to use the ingredientBonusCache instead of MAX_RECIPE_BONUS constant
    Removed MAX_RECIPE_CONSTANT
