### PR TITLE
Excluded ingredients add

### DIFF
--- a/backend/src/controllers/calculator/production.controller.ts
+++ b/backend/src/controllers/calculator/production.controller.ts
@@ -29,7 +29,8 @@ import type {
   SingleProductionRequest,
   TeamMemberExt,
   TeamSettings,
-  TeamSettingsExt
+  TeamSettingsExt,
+  Ingredient
 } from 'sleepapi-common';
 import {
   calculateRecipeValue,
@@ -44,7 +45,8 @@ import {
   limitSubSkillsToLevel,
   mainskill,
   MAX_POT_SIZE,
-  salad
+  salad,
+  ingredient
 } from 'sleepapi-common';
 
 export default class ProductionController {
@@ -167,14 +169,28 @@ export default class ProductionController {
       }
     }
 
-    return {
+    // Convert excluded ingredients from names to indices
+    const excludedIngredients = new Set<number>();
+    if (settings.excludedIngredients) {
+      for (const name of settings.excludedIngredients) {
+        const ing = getIngredient(name);
+        const index = ingredient.INGREDIENTS.findIndex((i: Ingredient) => i.name === ing.name);
+        if (index !== -1) {
+          excludedIngredients.add(index);
+        }
+      }
+    }
+
+    const result = {
       camp,
       bedtime,
       wakeup,
       includeCooking,
       stockpiledIngredients,
-      potSize
-    };
+      potSize,
+      excludedIngredients: excludedIngredients.size > 0 ? excludedIngredients : undefined
+    } satisfies TeamSettingsExt;
+    return result;
   }
 
   #parseTeamMembers(members: PokemonInstanceIdentity[], camp: boolean) {

--- a/backend/src/database/dao/team/__snapshots__/team-dao.test.ts.snap
+++ b/backend/src/database/dao/team/__snapshots__/team-dao.test.ts.snap
@@ -5,6 +5,7 @@ exports[`findTeamsWithMembers > shall get team with members 1`] = `
   {
     "bedtime": "21:30",
     "camp": false,
+    "excludedIngredients": [],
     "favoredBerries": undefined,
     "index": 0,
     "members": [

--- a/backend/src/database/dao/team/team-dao.ts
+++ b/backend/src/database/dao/team/team-dao.ts
@@ -24,7 +24,8 @@ const DBTeamSchema = Type.Composite([
     recipe_type: Type.Union([Type.Literal('curry'), Type.Literal('salad'), Type.Literal('dessert')]),
     favored_berries: Type.Optional(Type.String()),
     stockpiled_ingredients: Type.Optional(Type.String()),
-    stockpiled_berries: Type.Optional(Type.String())
+    stockpiled_berries: Type.Optional(Type.String()),
+    excluded_ingredients: Type.Optional(Type.String())
   })
 ]);
 export type DBTeam = Static<typeof DBTeamSchema>;
@@ -91,7 +92,8 @@ class TeamDAOImpl extends AbstractDAO<typeof DBTeamSchema> {
         stockpiledBerries: this.stringToStockpile(team.stockpiled_berries, true),
         stockpiledIngredients: this.stringToStockpile(team.stockpiled_ingredients, false),
         version: team.version,
-        members
+        members,
+        excludedIngredients: this.stringToExcludedIngredients(team.excluded_ingredients)
       });
     }
     return teamsWithMembers;
@@ -117,6 +119,21 @@ class TeamDAOImpl extends AbstractDAO<typeof DBTeamSchema> {
 
       return isBerry ? { ...base, level: Number(level) } : base;
     });
+  }
+
+  public excludedIngredientsToString(ingredients: string[] | undefined): string {
+    return ingredients ? JSON.stringify(ingredients) : '';
+  }
+
+  public stringToExcludedIngredients(ingredientsString: string | undefined): string[] {
+    if (!ingredientsString) {
+      return [];
+    }
+    try {
+      return JSON.parse(ingredientsString);
+    } catch {
+      return [];
+    }
   }
 }
 

--- a/backend/src/services/api-service/team/team-service.test.ts
+++ b/backend/src/services/api-service/team/team-service.test.ts
@@ -224,7 +224,8 @@ describe('getTeams', () => {
           wakeup: '06:00',
           version: 1,
           recipeType: 'curry',
-          favoredBerries: undefined
+          favoredBerries: undefined,
+          excludedIngredients: []
         },
         {
           index: 1,
@@ -235,7 +236,8 @@ describe('getTeams', () => {
           members: [],
           version: 1,
           recipeType: 'curry',
-          favoredBerries: undefined
+          favoredBerries: undefined,
+          excludedIngredients: []
         }
       ]
     });
@@ -289,7 +291,8 @@ describe('getTeams', () => {
           wakeup: '06:00',
           version: 1,
           recipeType: 'curry',
-          favoredBerries: undefined
+          favoredBerries: undefined,
+          excludedIngredients: []
         }
       ]
     });

--- a/backend/src/services/simulation-service/team-simulator/cooking-state/cooking-state.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/cooking-state/cooking-state.test.ts
@@ -151,4 +151,24 @@ describe('CookingState', () => {
 
     expect(cookingState['currentDessertStockpile']).toEqual(initialStockpile);
   });
+
+  it('shall not cook recipes with excluded ingredients', () => {
+    const excludedIngredients = new Set([ingredient.INGREDIENTS.findIndex((i) => i.name === 'HONEY')]);
+    const cookingState = new CookingState(
+      mocks.teamSettingsExt({ camp: true, potSize: MAX_POT_SIZE, excludedIngredients }),
+      defaultUserRecipes(),
+      createPreGeneratedRandom()
+    );
+
+    const ingsForMacaronsAndFlan = ingredientSetToFloatFlat([
+      ...dessert.JIGGLYPUFFS_FRUITY_FLAN.ingredients,
+      ...dessert.FLOWER_GIFT_MACARONS.ingredients
+    ]);
+    cookingState.addIngredients(ingsForMacaronsAndFlan);
+
+    cookingState.cook(false);
+
+    const result = cookingState.results(1);
+    expect(result.dessert.cookedRecipes.map((r) => r.recipe.name)).not.toContain('JIGGLYPUFFS_FRUITY_FLAN');
+  });
 });

--- a/common/src/api/team/get/get-team.ts
+++ b/common/src/api/team/get/get-team.ts
@@ -1,0 +1,19 @@
+import type { RecipeType } from '../../../domain/recipe/recipe';
+import type { IngredientSetSimple } from '../../../domain/ingredient/ingredient';
+import type { BerrySetSimple } from '../../../domain/berry/berry';
+import type { TeamMemberExt } from '../../../domain/team/member';
+
+export interface GetTeamResponse {
+  index: number;
+  name: string;
+  camp: boolean;
+  bedtime: string;
+  wakeup: string;
+  recipeType: RecipeType;
+  favoredBerries: string[];
+  stockpiledIngredients: IngredientSetSimple[];
+  stockpiledBerries: BerrySetSimple[];
+  excludedIngredients: string[];
+  version: number;
+  members: TeamMemberExt[];
+}

--- a/common/src/api/team/get/team-response.ts
+++ b/common/src/api/team/get/team-response.ts
@@ -12,6 +12,7 @@ export interface GetTeamResponse {
   favoredBerries?: string[];
   stockpiledBerries?: BerrySetSimple[];
   stockpiledIngredients?: IngredientSetSimple[];
+  excludedIngredients?: string[];
   version: number;
 
   members: MemberInstance[];

--- a/common/src/api/team/meta/upsert-team.ts
+++ b/common/src/api/team/meta/upsert-team.ts
@@ -10,6 +10,7 @@ export interface UpsertTeamMetaRequest {
   favoredBerries?: string[];
   stockpiledIngredients?: IngredientSetSimple[];
   stockpiledBerries?: BerrySetSimple[];
+  excludedIngredients?: string[];
 }
 
 export interface UpsertTeamMetaResponse {
@@ -23,4 +24,5 @@ export interface UpsertTeamMetaResponse {
   favoredBerries?: string[];
   stockpiledIngredients?: IngredientSetSimple[];
   stockpiledBerries?: BerrySetSimple[];
+  excludedIngredients?: string[];
 }

--- a/common/src/domain/team/team.ts
+++ b/common/src/domain/team/team.ts
@@ -8,6 +8,7 @@ export interface TeamSettings {
   bedtime: string;
   wakeup: string;
   stockpiledIngredients?: IngredientSetSimple[];
+  excludedIngredients?: string[];
 }
 export interface TeamSettingsExt {
   camp: boolean;
@@ -16,6 +17,7 @@ export interface TeamSettingsExt {
   includeCooking: boolean;
   stockpiledIngredients: IngredientIndexToFloatAmount;
   potSize: number;
+  excludedIngredients?: Set<number>;
 }
 
 export interface TeamSolution {

--- a/frontend/src/stores/team/team-store.test.ts
+++ b/frontend/src/stores/team/team-store.test.ts
@@ -971,7 +971,7 @@ describe('updateStockpile', () => {
     const ingredients = [mockIngredientSetSimple({ amount: 10 })]
     const berries = [mockBerrySetSimple({ amount: 5 })]
 
-    await teamStore.updateStockpile({ ingredients, berries })
+    await teamStore.updateStockpile({ ingredients, berries, excludedIngredients: [] })
 
     expect(teamStore.getCurrentTeam.stockpiledIngredients).toEqual(ingredients)
     expect(teamStore.getCurrentTeam.stockpiledBerries).toEqual(berries)
@@ -986,7 +986,7 @@ describe('updateStockpile', () => {
 
     teamStore.calculateProduction = vi.fn()
 
-    await teamStore.updateStockpile({ ingredients, berries })
+    await teamStore.updateStockpile({ ingredients, berries, excludedIngredients: [] })
 
     expect(teamStore.calculateProduction).toHaveBeenCalled()
   })

--- a/frontend/src/stores/team/team-store.ts
+++ b/frontend/src/stores/team/team-store.ts
@@ -344,7 +344,8 @@ export const useTeamStore = defineStore('team', {
         camp: this.teams[teamIndex].camp,
         bedtime: this.teams[teamIndex].bedtime,
         wakeup: this.teams[teamIndex].wakeup,
-        stockpiledIngredients: this.teams[teamIndex].stockpiledIngredients
+        stockpiledIngredients: this.teams[teamIndex].stockpiledIngredients,
+        excludedIngredients: this.teams[teamIndex].excludedIngredients
       }
       this.teams[teamIndex].production = await TeamService.calculateProduction({
         members,
@@ -417,10 +418,15 @@ export const useTeamStore = defineStore('team', {
       await this.calculateProduction(this.currentIndex)
       this.resetCurrentTeamIvs() // reset after production is available
     },
-    async updateStockpile(params: { ingredients: IngredientSetSimple[]; berries: BerrySetSimple[] }) {
-      const { ingredients, berries } = params
+    async updateStockpile(params: {
+      ingredients: IngredientSetSimple[]
+      berries: BerrySetSimple[]
+      excludedIngredients: string[]
+    }) {
+      const { ingredients, berries, excludedIngredients } = params
       this.getCurrentTeam.stockpiledIngredients = ingredients
       this.getCurrentTeam.stockpiledBerries = berries
+      this.getCurrentTeam.excludedIngredients = excludedIngredients
 
       this.updateTeam()
       await this.calculateProduction(this.currentIndex)

--- a/frontend/src/types/member/instanced.ts
+++ b/frontend/src/types/member/instanced.ts
@@ -47,6 +47,7 @@ export interface TeamInstance {
   members: (string | undefined)[]
   memberIvs: Record<string, PerformanceDetails | undefined>
   production?: TeamProductionExt
+  excludedIngredients?: string[]
 }
 
 // TODO: exists in common, clean up


### PR DESCRIPTION
Added settings to exclude certain ingredients from 'split of recipe cooked' calculation. 

i.e. if user wants to remove slowpoke tails and leeks from resources being used