### PR TITLE
fix(auth)!: patreon supporter status links correctly

### DIFF
--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -15,7 +15,7 @@
         "knex": "^3.1.0",
         "morgan": "~1.9.1",
         "mysql2": "~3.9.7",
-        "patreon-api.ts": "^0.12.0",
+        "patreon-api.ts": "^0.12.3",
         "seedrandom": "^3.0.5",
         "swagger-ui-express": "^5.0.0",
         "tsoa": "^6.6.0",
@@ -848,7 +848,7 @@
 
     "pathval": ["pathval@2.0.0", "", {}, "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA=="],
 
-    "patreon-api.ts": ["patreon-api.ts@0.12.1", "", {}, "sha512-gJdgFl6Gfpz9OSiVf62EFf1AY8VrE8hN5gCJWHf9pNWPWDrrbX2rWlekx5ltjeV0iYT+LPizpaRKdhkHIbfwHw=="],
+    "patreon-api.ts": ["patreon-api.ts@0.12.3", "", {}, "sha512-RnQm1XPLu6lISsf4k0rrT7+TdWwKicUTlVsNhMyPSCI0fPmsyz3qNI41qqaGmPOwcM3IuBpqZA7tU5zqUIzykw=="],
 
     "pg-connection-string": ["pg-connection-string@2.6.2", "", {}, "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="],
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,7 +22,7 @@
         "knex": "^3.1.0",
         "morgan": "~1.9.1",
         "mysql2": "~3.9.7",
-        "patreon-api.ts": "^0.12.0",
+        "patreon-api.ts": "^0.12.3",
         "seedrandom": "^3.0.5",
         "swagger-ui-express": "^5.0.0",
         "tsoa": "^6.6.0",
@@ -5355,9 +5355,9 @@
       }
     },
     "node_modules/patreon-api.ts": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/patreon-api.ts/-/patreon-api.ts-0.12.0.tgz",
-      "integrity": "sha512-0T4LfS1nWkiebcc/cB5ZBvHEPyU/kxW7uP3h0ZpPZdvA90Zub7r4teIPIlNNOpTzasg25ptuJFsrmszl5gnE0w==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/patreon-api.ts/-/patreon-api.ts-0.12.3.tgz",
+      "integrity": "sha512-RnQm1XPLu6lISsf4k0rrT7+TdWwKicUTlVsNhMyPSCI0fPmsyz3qNI41qqaGmPOwcM3IuBpqZA7tU5zqUIzykw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/backend/package.json
+++ b/backend/package.json
@@ -50,7 +50,7 @@
     "knex": "^3.1.0",
     "morgan": "~1.9.1",
     "mysql2": "~3.9.7",
-    "patreon-api.ts": "^0.12.0",
+    "patreon-api.ts": "^0.12.3",
     "seedrandom": "^3.0.5",
     "swagger-ui-express": "^5.0.0",
     "tsoa": "^6.6.0",

--- a/backend/src/config/config.test.ts
+++ b/backend/src/config/config.test.ts
@@ -22,6 +22,8 @@ describe('config', () => {
         "NODE_ENV": "DEV",
         "PATREON_CLIENT_ID": "Missing env variable for PATREON_CLIENT_ID, you can add it to backend/.env",
         "PATREON_CLIENT_SECRET": "Missing env variable for PATREON_CLIENT_SECRET, you can add it to backend/.env",
+        "PATREON_CREATOR_ACCESS_TOKEN": "Missing env variable for PATREON_CREATOR_ACCESS_TOKEN, you can add it to backend/.env",
+        "PATREON_CREATOR_REFRESH_TOKEN": "Missing env variable for PATREON_CREATOR_REFRESH_TOKEN, you can add it to backend/.env",
         "PORT": 3000,
         "ROLLBACK_BATCHES": undefined,
       }
@@ -46,6 +48,8 @@ describe('config', () => {
     process.env.DISCORD_CLIENT_SECRET = 'some-discord-secret';
     process.env.PATREON_CLIENT_ID = 'some-patreon-id';
     process.env.PATREON_CLIENT_SECRET = 'some-patreon-secret';
+    process.env.PATREON_CREATOR_ACCESS_TOKEN = 'some-patreon-creator-access-token';
+    process.env.PATREON_CREATOR_REFRESH_TOKEN = 'some-patreon-creator-refresh-token';
 
     expect(backendConfig.config).toMatchInlineSnapshot(`
       {
@@ -63,6 +67,8 @@ describe('config', () => {
         "NODE_ENV": "DEV",
         "PATREON_CLIENT_ID": "some-patreon-id",
         "PATREON_CLIENT_SECRET": "some-patreon-secret",
+        "PATREON_CREATOR_ACCESS_TOKEN": "some-patreon-creator-access-token",
+        "PATREON_CREATOR_REFRESH_TOKEN": "some-patreon-creator-refresh-token",
         "PORT": "2",
         "ROLLBACK_BATCHES": 3,
       }

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -41,6 +41,8 @@ export class BackendConfig {
       DISCORD_CLIENT_SECRET: getProductionVariable('DISCORD_CLIENT_SECRET'),
       PATREON_CLIENT_ID: getProductionVariable('PATREON_CLIENT_ID'),
       PATREON_CLIENT_SECRET: getProductionVariable('PATREON_CLIENT_SECRET'),
+      PATREON_CREATOR_ACCESS_TOKEN: getProductionVariable('PATREON_CREATOR_ACCESS_TOKEN'),
+      PATREON_CREATOR_REFRESH_TOKEN: getProductionVariable('PATREON_CREATOR_REFRESH_TOKEN'),
       GENERATE_TIERLIST: GENERATE_TIERLIST === 'true',
       DATABASE_NAME: getProductionVariable('DATABASE_NAME')
     };

--- a/backend/src/controllers/user/user.controller.ts
+++ b/backend/src/controllers/user/user.controller.ts
@@ -15,15 +15,15 @@ import {
   updateUser,
   upsertUserSettings
 } from '@src/services/user-service/user-service.js';
-import type { IslandShortName, PokemonInstanceWithMeta, UpdateUserRequest, UserHeader } from 'sleepapi-common';
+import type { IslandShortName, PokemonInstanceWithMeta, UpdateUserRequest } from 'sleepapi-common';
 
 export default class UserController {
   public async updateUser(user: DBUser, newSettings: Partial<UpdateUserRequest>) {
     return updateUser(user, newSettings);
   }
 
-  public async getUserSettings(user: DBUser, userHeader: UserHeader) {
-    return getUserSettings(user, userHeader);
+  public async getUserSettings(user: DBUser) {
+    return getUserSettings(user);
   }
 
   public async upsertUserSettings(user: DBUser, potSize: number) {

--- a/backend/src/routes/user-router/user-router.ts
+++ b/backend/src/routes/user-router/user-router.ts
@@ -65,7 +65,7 @@ class UserRouterImpl {
         if (!user) {
           throw new Error('User not found');
         }
-        const data = await controller.getUserSettings(user, authentication.userHeader);
+        const data = await controller.getUserSettings(user);
 
         res.json(data);
       } catch (err) {

--- a/backend/src/services/user-service/login-service/providers/abstract-provider.ts
+++ b/backend/src/services/user-service/login-service/providers/abstract-provider.ts
@@ -27,5 +27,5 @@ export abstract class AbstractProvider<TClient> {
     return user;
   }
 
-  abstract updateLastLogin(auth_id: string, role?: Roles): Promise<DBUser>;
+  abstract updateLastLogin(user: DBUser, role?: Roles): Promise<DBUser>;
 }

--- a/backend/src/services/user-service/login-service/providers/discord/discord-provider.test.ts
+++ b/backend/src/services/user-service/login-service/providers/discord/discord-provider.test.ts
@@ -160,9 +160,9 @@ describe('DiscordProvider', () => {
   describe('updateLastLogin', () => {
     it('should update the last login date', async () => {
       const discordId = 'mockDiscordId';
-      await UserDAO.insert(mocks.dbUser({ discord_id: discordId }));
+      const user = await UserDAO.insert(mocks.dbUser({ discord_id: discordId }));
       const initialDate = new Date();
-      await DiscordProvider.updateLastLogin(discordId);
+      await DiscordProvider.updateLastLogin(user);
 
       const updatedUser = await UserDAO.find({ discord_id: discordId });
       expect(updatedUser?.last_login).not.toEqual(initialDate);

--- a/backend/src/services/user-service/login-service/providers/discord/discord-provider.ts
+++ b/backend/src/services/user-service/login-service/providers/discord/discord-provider.ts
@@ -129,11 +129,11 @@ export class DiscordProviderImpl extends AbstractProvider<DiscordOauth2> {
 
   async verifyExistingUser(userHeader: UserHeader): Promise<DBUser> {
     const userData: DiscordUser = await this.getClient(userHeader.Redirect).getUser(userHeader.Authorization);
-    return this.updateLastLogin(userData.id);
+    const user = await UserDAO.get({ discord_id: userData.id });
+    return this.updateLastLogin(user);
   }
 
-  async updateLastLogin(auth_id: string): Promise<DBUser> {
-    const user = await UserDAO.get({ discord_id: auth_id });
+  async updateLastLogin(user: DBUser): Promise<DBUser> {
     return UserDAO.update({ ...user, last_login: new Date() });
   }
 }

--- a/backend/src/services/user-service/login-service/providers/google/google-provider.test.ts
+++ b/backend/src/services/user-service/login-service/providers/google/google-provider.test.ts
@@ -174,9 +174,9 @@ describe('GoogleProvider', () => {
   describe('updateLastLogin', () => {
     it('should update the last login date', async () => {
       const googleId = 'mockSub';
-      await UserDAO.insert(mocks.dbUser({ google_id: googleId }));
+      const user = await UserDAO.insert(mocks.dbUser({ google_id: googleId }));
       const initialDate = new Date();
-      await GoogleProvider.updateLastLogin(googleId);
+      await GoogleProvider.updateLastLogin(user);
 
       const updatedUser = await UserDAO.find({ google_id: googleId });
       expect(updatedUser?.last_login).not.toEqual(initialDate);

--- a/backend/src/services/user-service/login-service/providers/google/google-provider.ts
+++ b/backend/src/services/user-service/login-service/providers/google/google-provider.ts
@@ -128,11 +128,11 @@ export class GoogleProviderImpl extends AbstractProvider<OAuth2Client> {
       throw new AuthorizationError('Missing sub in Google token info response');
     }
 
-    return this.updateLastLogin(response.data.sub);
+    const user = await UserDAO.get({ google_id: response.data.sub });
+    return this.updateLastLogin(user);
   }
 
-  async updateLastLogin(auth_id: string): Promise<DBUser> {
-    const user = await UserDAO.get({ google_id: auth_id });
+  async updateLastLogin(user: DBUser): Promise<DBUser> {
     return UserDAO.update({ ...user, last_login: new Date() });
   }
 }

--- a/backend/src/services/user-service/login-service/providers/patreon/patreon-provider.test.ts
+++ b/backend/src/services/user-service/login-service/providers/patreon/patreon-provider.test.ts
@@ -1,99 +1,50 @@
+import { config } from '@src/config/config.js';
 import type { DBUser } from '@src/database/dao/user/user-dao.js';
 import { UserDAO } from '@src/database/dao/user/user-dao.js';
 import { PatreonProvider } from '@src/services/user-service/login-service/providers/patreon/patreon-provider.js';
 import { DaoFixture } from '@src/utils/test-utils/dao-fixture.js';
 import { mocks } from '@src/vitest/index.js';
-import { AuthProvider, Roles, uuid } from 'sleepapi-common';
-import { describe, expect, it } from 'vitest';
+import * as PatreonAPI from 'patreon-api.ts';
+import { AuthProvider, Roles } from 'sleepapi-common';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 DaoFixture.init({ recreateDatabasesBeforeEachTest: true });
 
-interface MockPatronMembership {
-  patronStatus: string;
-  pledgeRelationshipStart?: string;
-}
-
-interface MockPatronResponse {
-  data: {
-    id: string;
-    attributes: {
-      email: string;
-    };
-  };
-  memberships: MockPatronMembership[];
-}
-
-const mockPatronData: Record<'active' | 'inactive', MockPatronResponse> = {
-  active: {
-    data: {
-      id: 'mockPatreonId',
-      attributes: {
-        email: 'mock@patreon.com'
-      }
-    },
-    memberships: [
-      {
-        patronStatus: 'active_patron',
-        pledgeRelationshipStart: '2024-01-01T00:00:00.000Z'
-      }
-    ]
-  },
-  inactive: {
-    data: {
-      id: 'mockPatreonId',
-      attributes: {
-        email: 'mock@patreon.com'
-      }
-    },
-    memberships: [
-      {
-        patronStatus: 'former_patron'
-      }
-    ]
-  }
-};
-
-let currentPatronData = mockPatronData.active;
-
-vi.mock('patreon-api.ts', () => {
+vi.mock('patreon-api.ts', async () => {
+  const actual = await vi.importActual('patreon-api.ts');
   return {
-    PatreonUserClient: vi.fn().mockImplementation(() => ({
-      oauth: {
-        getOauthTokenFromCode: vi.fn().mockResolvedValue({
-          access_token: 'mockAccessToken',
-          refresh_token: 'mockRefreshToken',
-          expires_in_epoch: Date.now() + 3600000 // 1 hour from now
-        }),
-        refreshToken: vi.fn().mockResolvedValue({
-          access_token: 'mockNewAccessToken',
-          expires_in_epoch: Date.now() + 3600000
-        })
-      },
-      fetchIdentity: vi.fn().mockImplementation(() => Promise.resolve(currentPatronData))
-    })),
-    QueryBuilder: {
-      identity: {
-        addRelationships: vi.fn().mockReturnThis(),
-        setAttributes: vi.fn().mockReturnThis()
-      }
-    },
-    PatreonOauthScope: {
-      IdentityEmail: 'identity.email'
-    },
-    simplify: vi.fn().mockImplementation(() => ({
-      memberships: currentPatronData.memberships
-    }))
+    ...actual,
+    PatreonUserClient: vi.fn(),
+    PatreonCreatorClient: vi.fn(),
+    simplify: vi.fn()
   };
 });
 
+vi.mock('@src/config/config.js', async () => ({
+  config: {
+    PATREON_CLIENT_ID: 'mockPatreonClientId',
+    PATREON_CLIENT_SECRET: 'mockPatreonClientSecret',
+    PATREON_CREATOR_ACCESS_TOKEN: 'mockPatreonAccessToken',
+    PATREON_CREATOR_REFRESH_TOKEN: 'mockPatreonRefreshToken'
+  }
+}));
+
+const MOCK_SUPPORTING_USER_ID = 'supporting-user-id';
+const MOCK_SUPPORTING_USER_EMAIL = 'supporting-user@patreon.com';
+const MOCK_NON_SUPPORTING_USER_ID = 'non-supporting-user-id';
+const MOCK_NON_SUPPORTING_USER_EMAIL = 'non-supporting-user@patreon.com';
+
 describe('PatreonProvider', () => {
   beforeEach(() => {
-    PatreonProvider.client = undefined;
-    currentPatronData = mockPatronData.active;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(PatreonAPI.simplify).mockImplementation((data: any) => data);
   });
 
-  it('should be defined', () => {
-    expect(PatreonProvider).toBeDefined();
+  afterEach(() => {
+    process.env = {};
+    resetPatreonProvider();
+
+    vi.clearAllMocks();
   });
 
   it('should have a provider', () => {
@@ -110,12 +61,55 @@ describe('PatreonProvider', () => {
     });
 
     it('should call getUserClient and create a client when calling signup', async () => {
-      expect(PatreonProvider.client).toBeUndefined();
-      await PatreonProvider.signup({
-        authorization_code: '1234567890',
-        redirect_uri: 'http://localhost:3000'
+      mockUserClient({});
+      mockCreatorClient();
+      const redirect_uri = 'http://localhost:3000';
+
+      const { auth, role } = await PatreonProvider.signup({
+        authorization_code: 'some-authorization-code',
+        redirect_uri
       });
-      expect(PatreonProvider.client).toBeDefined();
+
+      // assert token exchange
+      expect(PatreonAPI.PatreonUserClient).toHaveBeenCalledWith({
+        oauth: {
+          clientId: config.PATREON_CLIENT_ID,
+          clientSecret: config.PATREON_CLIENT_SECRET,
+          redirectUri: redirect_uri,
+          scopes: [PatreonAPI.PatreonOauthScope.Identity, PatreonAPI.PatreonOauthScope.IdentityEmail]
+        }
+      });
+      expect(mockedUserClient.oauth.getOauthTokenFromCode).toHaveBeenCalledWith({
+        code: 'some-authorization-code'
+      });
+
+      // assert user was identified
+      expect(mockedUserClient.fetchIdentity).toHaveBeenCalledWith(
+        PatreonAPI.QueryBuilder.identity.setAttributes({
+          user: ['email']
+        }),
+        {
+          token: 'mockAccessToken'
+        }
+      );
+
+      // assert campaign members were fetched
+      expect(mockedCreatorClient.fetchCampaignMembers).toHaveBeenCalledWith(
+        '12771188', // neroli campaign id
+        PatreonAPI.QueryBuilder.campaignMembers
+          .addRelationships(['user'])
+          .setAttributes({
+            member: ['patron_status', 'pledge_relationship_start']
+          })
+          .setRequestOptions({ count: 1000 })
+      );
+
+      // assert result
+      expect(auth.linkedProviders[AuthProvider.Patreon].linked).toBe(true);
+      expect(auth.linkedProviders[AuthProvider.Patreon].identifier).toMatchInlineSnapshot(
+        `"non-supporting-user@patreon.com"`
+      );
+      expect(role).toBe(Roles.Default);
     });
 
     it('should exchange authorization code for tokens and create a user if they do not exist', async () => {
@@ -132,16 +126,21 @@ describe('PatreonProvider', () => {
       expect(user.auth.tokens.refreshToken).toMatchInlineSnapshot(`"mockRefreshToken"`);
       expect(user.auth.tokens.expiryDate).toBeDefined();
       expect(user.auth.linkedProviders[AuthProvider.Patreon].linked).toBe(true);
-      expect(user.auth.linkedProviders[AuthProvider.Patreon].identifier).toMatchInlineSnapshot(`"mock@patreon.com"`);
-      expect(user.role).toBe(Roles.Supporter);
+      expect(user.auth.linkedProviders[AuthProvider.Patreon].identifier).toMatchInlineSnapshot(
+        `"non-supporting-user@patreon.com"`
+      );
+      expect(user.role).toBe(Roles.Default);
 
       const insertedUser = await UserDAO.findMultiple();
       expect(insertedUser).toHaveLength(1);
-      expect(insertedUser[0].patreon_id).toBe('mockPatreonId');
-      expect(insertedUser[0].role).toBe(Roles.Supporter);
+      expect(insertedUser[0].patreon_id).toBe('non-supporting-user-id');
+      expect(insertedUser[0].role).toBe(Roles.Default);
     });
 
     it('should add patreon link to user if they already exist', async () => {
+      const accessToken = 'mockAccessToken';
+      mockUserClient({ access_token: accessToken });
+      mockCreatorClient();
       const user: DBUser = mocks.dbUser({ discord_id: 'discord id' });
       await UserDAO.insert(user);
 
@@ -152,21 +151,43 @@ describe('PatreonProvider', () => {
         redirect_uri: 'http://localhost:3000',
         preExistingUser: user
       });
+
+      // Verify client setup and token exchange
+      expect(PatreonAPI.PatreonUserClient).toHaveBeenCalledWith({
+        oauth: {
+          clientId: config.PATREON_CLIENT_ID,
+          clientSecret: config.PATREON_CLIENT_SECRET,
+          redirectUri: 'http://localhost:3000',
+          scopes: [PatreonAPI.PatreonOauthScope.Identity, PatreonAPI.PatreonOauthScope.IdentityEmail]
+        }
+      });
+
+      expect(mockedUserClient.oauth.getOauthTokenFromCode).toHaveBeenCalledWith({
+        code: '1234567890'
+      });
+
+      // Verify user was identified
+      expect(mockedUserClient.fetchIdentity).toHaveBeenCalledWith(
+        PatreonAPI.QueryBuilder.identity.setAttributes({
+          user: ['email']
+        }),
+        {
+          token: accessToken
+        }
+      );
+
+      // Verify result
       expect(updatedUser.auth.linkedProviders[AuthProvider.Patreon].linked).toBe(true);
       expect(updatedUser.auth.linkedProviders[AuthProvider.Discord].linked).toBe(true);
-      expect(updatedUser.auth.linkedProviders[AuthProvider.Patreon].identifier).toMatchInlineSnapshot(
-        `"mock@patreon.com"`
-      );
-      expect(updatedUser.role).toBe(Roles.Supporter);
+      expect(updatedUser.auth.linkedProviders[AuthProvider.Patreon].identifier).toBe(MOCK_NON_SUPPORTING_USER_EMAIL);
+      expect(updatedUser.role).toBe(Roles.Default);
 
       const dbUser = await UserDAO.find({ id: user.id });
-      expect(dbUser?.patreon_id).toMatchInlineSnapshot(`"mockPatreonId"`);
-      expect(dbUser?.role).toBe(Roles.Supporter);
+      expect(dbUser?.patreon_id).toBe(MOCK_NON_SUPPORTING_USER_ID);
+      expect(dbUser?.role).toBe(Roles.Default);
     });
 
     it('should set role to Default for non-active patrons during signup', async () => {
-      currentPatronData = mockPatronData.inactive;
-
       const user = await PatreonProvider.signup({
         authorization_code: '1234567890',
         redirect_uri: 'http://localhost:3000'
@@ -181,8 +202,14 @@ describe('PatreonProvider', () => {
     });
 
     it('should return users that already exist', async () => {
-      const user: DBUser = mocks.dbUser({ patreon_id: 'mockPatreonId', external_id: uuid.v4() });
-      await UserDAO.insert(user);
+      mockUserClient({});
+      mockCreatorClient();
+      const user = await UserDAO.insert(
+        mocks.dbUser({
+          patreon_id: MOCK_NON_SUPPORTING_USER_ID,
+          external_id: 'test-external-id'
+        })
+      );
 
       const updatedUser = await PatreonProvider.signup({
         authorization_code: '1234567890',
@@ -190,6 +217,7 @@ describe('PatreonProvider', () => {
       });
 
       expect(updatedUser.externalId).toEqual(user.external_id);
+      expect(updatedUser.auth.linkedProviders[AuthProvider.Patreon].identifier).toBe(MOCK_NON_SUPPORTING_USER_EMAIL);
     });
   });
 
@@ -199,22 +227,36 @@ describe('PatreonProvider', () => {
     });
 
     it('should call getUserClient and create a client when calling refresh', async () => {
-      expect(PatreonProvider.client).toBeUndefined();
+      mockUserClient({});
+      const refresh_token = '1234567890';
+      const redirect_uri = 'http://localhost:3000';
+
       await PatreonProvider.refresh({
-        refresh_token: '1234567890',
-        redirect_uri: 'http://localhost:3000'
+        refresh_token,
+        redirect_uri
       });
-      expect(PatreonProvider.client).toBeDefined();
+
+      expect(PatreonAPI.PatreonUserClient).toHaveBeenCalledWith({
+        oauth: {
+          clientId: config.PATREON_CLIENT_ID,
+          clientSecret: config.PATREON_CLIENT_SECRET,
+          redirectUri: redirect_uri,
+          scopes: [PatreonAPI.PatreonOauthScope.Identity, PatreonAPI.PatreonOauthScope.IdentityEmail]
+        }
+      });
+
+      expect(mockedUserClient.oauth.refreshToken).toHaveBeenCalledWith(refresh_token);
     });
 
     it('should call Patreon to refresh the token', async () => {
+      mockUserClient({});
       const refreshToken = '1234567890';
       const { access_token, expiry_date } = await PatreonProvider.refresh({
         refresh_token: refreshToken,
         redirect_uri: 'http://localhost:3000'
       });
 
-      expect(access_token).toMatchInlineSnapshot(`"mockNewAccessToken"`);
+      expect(access_token).toBe('mockNewAccessToken');
       expect(expiry_date).toBeDefined();
     });
   });
@@ -232,11 +274,52 @@ describe('PatreonProvider', () => {
 
   describe('verifyExistingUser', () => {
     it('should call Patreon to verify the user and update the last login date and role', async () => {
+      mockUserClient({
+        id: MOCK_SUPPORTING_USER_ID,
+        email: MOCK_SUPPORTING_USER_EMAIL
+      });
+      mockCreatorClient();
       const initialDate = new Date();
-      await UserDAO.insert(mocks.dbUser({ patreon_id: 'mockPatreonId', last_login: initialDate, role: Roles.Default }));
-      await PatreonProvider.verifyExistingUser(mocks.userHeader({ Authorization: 'mockAccessToken' }));
 
-      const updatedUser = await UserDAO.find({ patreon_id: 'mockPatreonId' });
+      // Create a user that matches what our mocked client will return
+      await UserDAO.insert(
+        mocks.dbUser({
+          patreon_id: MOCK_SUPPORTING_USER_ID,
+          last_login: initialDate,
+          role: Roles.Default
+        })
+      );
+
+      await PatreonProvider.verifyExistingUser(
+        mocks.userHeader({
+          Authorization: 'mockAccessToken',
+          Redirect: 'http://localhost:3000'
+        })
+      );
+
+      // Verify identity was fetched
+      expect(mockedUserClient.fetchIdentity).toHaveBeenCalledWith(
+        PatreonAPI.QueryBuilder.identity.setAttributes({
+          user: ['email']
+        }),
+        {
+          token: 'mockAccessToken'
+        }
+      );
+
+      // Verify campaign members were checked
+      expect(mockedCreatorClient.fetchCampaignMembers).toHaveBeenCalledWith(
+        '12771188',
+        PatreonAPI.QueryBuilder.campaignMembers
+          .addRelationships(['user'])
+          .setAttributes({
+            member: ['patron_status', 'pledge_relationship_start']
+          })
+          .setRequestOptions({ count: 1000 })
+      );
+
+      // Verify user was updated
+      const updatedUser = await UserDAO.find({ patreon_id: MOCK_SUPPORTING_USER_ID });
       expect(updatedUser?.last_login).not.toEqual(initialDate);
       expect(updatedUser?.role).toBe(Roles.Supporter);
     });
@@ -245,9 +328,9 @@ describe('PatreonProvider', () => {
   describe('updateLastLogin', () => {
     it('should update the last login date and role', async () => {
       const patreonId = 'mockPatreonId';
-      await UserDAO.insert(mocks.dbUser({ patreon_id: patreonId, role: Roles.Default }));
+      const user = await UserDAO.insert(mocks.dbUser({ patreon_id: patreonId, role: Roles.Default }));
       const initialDate = new Date();
-      await PatreonProvider.updateLastLogin(patreonId, Roles.Supporter);
+      await PatreonProvider.updateLastLogin(user, Roles.Supporter);
 
       const updatedUser = await UserDAO.find({ patreon_id: patreonId });
       expect(updatedUser?.last_login).not.toEqual(initialDate);
@@ -255,18 +338,125 @@ describe('PatreonProvider', () => {
     });
   });
 
-  describe('getPatronStatus', () => {
+  describe('isSupporter', () => {
     it('should return supporter role for active patrons', async () => {
-      const { role, patreon_id, identifier, patronSince } = await PatreonProvider.getPatronStatus({
+      mockCreatorClient();
+      const { role, patronSince } = await PatreonProvider.isSupporter({
+        patreon_id: MOCK_SUPPORTING_USER_ID
+      });
+
+      expect(mockedCreatorClient.fetchCampaignMembers).toHaveBeenCalledWith(
+        '12771188',
+        PatreonAPI.QueryBuilder.campaignMembers
+          .addRelationships(['user'])
+          .setAttributes({
+            member: ['patron_status', 'pledge_relationship_start']
+          })
+          .setRequestOptions({ count: 1000 })
+      );
+
+      expect(role).toBe(Roles.Supporter);
+      expect(patronSince).toBe('2024-01-01T00:00:00.000Z');
+    });
+  });
+
+  describe('getPatronId', () => {
+    it('should return the patron id', async () => {
+      mockUserClient({
+        id: MOCK_SUPPORTING_USER_ID,
+        email: MOCK_SUPPORTING_USER_EMAIL
+      });
+
+      const { patreon_id, identifier } = await PatreonProvider.getPatronId({
         token: 'mockAccessToken',
         redirect_uri: 'http://localhost:3000'
       });
 
-      expect(PatreonProvider.client?.fetchIdentity).toHaveBeenCalled();
-      expect(role).toBe(Roles.Supporter);
-      expect(patreon_id).toBe('mockPatreonId');
-      expect(identifier).toBe('mock@patreon.com');
-      expect(patronSince).toBe('2024-01-01T00:00:00.000Z');
+      expect(mockedUserClient.fetchIdentity).toHaveBeenCalledWith(
+        PatreonAPI.QueryBuilder.identity.setAttributes({
+          user: ['email']
+        }),
+        {
+          token: 'mockAccessToken'
+        }
+      );
+
+      expect(patreon_id).toBe(MOCK_SUPPORTING_USER_ID);
+      expect(identifier).toBe(MOCK_SUPPORTING_USER_EMAIL);
     });
   });
 });
+
+let mockedUserClient: PatreonAPI.PatreonUserClient;
+function mockUserClient(params: {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in_epoch?: string;
+  id?: string;
+  email?: string;
+}) {
+  const {
+    access_token = 'mockAccessToken',
+    refresh_token = 'mockRefreshToken',
+    expires_in_epoch = new Date().getTime() + 1000 * 60 * 60,
+    id = MOCK_NON_SUPPORTING_USER_ID,
+    email = MOCK_NON_SUPPORTING_USER_EMAIL
+  } = params;
+
+  mockedUserClient = {
+    oauth: {
+      getOauthTokenFromCode: vi.fn().mockResolvedValue({
+        access_token,
+        refresh_token,
+        expires_in_epoch
+      }),
+      refreshToken: vi.fn().mockResolvedValue({
+        access_token: 'mockNewAccessToken',
+        expires_in_epoch: new Date().getTime() + 1000 * 60 * 60
+      })
+    },
+    fetchIdentity: vi.fn().mockResolvedValue({
+      id,
+      email
+    })
+  } as unknown as PatreonAPI.PatreonUserClient;
+
+  vi.mocked(PatreonAPI.PatreonUserClient).mockImplementation(() => mockedUserClient);
+}
+
+let mockedCreatorClient: PatreonAPI.PatreonCreatorClient;
+function mockCreatorClient() {
+  mockedCreatorClient = {
+    fetchCampaignMembers: vi.fn().mockResolvedValue({
+      data: [
+        {
+          user: {
+            id: MOCK_SUPPORTING_USER_ID,
+            email: MOCK_SUPPORTING_USER_EMAIL
+          },
+          patronStatus: 'active_patron',
+          pledgeRelationshipStart: '2024-01-01T00:00:00.000Z'
+        },
+        {
+          user: {
+            id: MOCK_NON_SUPPORTING_USER_ID,
+            email: MOCK_NON_SUPPORTING_USER_EMAIL
+          },
+          patronStatus: null,
+          pledgeRelationshipStart: undefined
+        }
+      ]
+    })
+  } as unknown as PatreonAPI.PatreonCreatorClient;
+
+  vi.mocked(PatreonAPI.PatreonCreatorClient).mockImplementation(() => mockedCreatorClient);
+}
+
+function resetPatreonProvider() {
+  PatreonProvider.client = undefined;
+  PatreonProvider.creatorClient = undefined;
+  // @ts-expect-error accessing private field for testing
+  PatreonProvider.patrons = new Map();
+  // @ts-expect-error accessing private field for testing
+  PatreonProvider.lastPatronsUpdate = 0;
+}

--- a/backend/src/services/user-service/login-service/providers/patreon/patreon-provider.ts
+++ b/backend/src/services/user-service/login-service/providers/patreon/patreon-provider.ts
@@ -3,18 +3,32 @@ import { UserDAO, type DBUser } from '@src/database/dao/user/user-dao.js';
 import { AuthorizationError } from '@src/domain/error/api/api-error.js';
 import { generateFriendCode } from '@src/services/user-service/login-service/login-utils.js';
 import { AbstractProvider } from '@src/services/user-service/login-service/providers/abstract-provider.js';
-import { PatreonOauthScope, PatreonUserClient, QueryBuilder, simplify } from 'patreon-api.ts';
+import type { Patron } from '@src/services/user-service/login-service/providers/patreon/patreon-types.js';
+import { PatreonCreatorClient, PatreonOauthScope, PatreonUserClient, QueryBuilder, simplify } from 'patreon-api.ts';
 import type { LoginResponse, RefreshResponse, UserHeader } from 'sleepapi-common';
 import { AuthProvider, Roles, uuid } from 'sleepapi-common';
 
 export class PatreonProviderImpl extends AbstractProvider<PatreonUserClient> {
   provider = AuthProvider.Patreon;
   client: PatreonUserClient | undefined;
+  creatorClient: PatreonCreatorClient | undefined;
 
-  private identityQuery = QueryBuilder.identity.addRelationships(['memberships']).setAttributes({
-    member: ['patron_status', 'pledge_relationship_start'],
+  private patrons: Map<string, Patron> = new Map();
+  private lastPatronsUpdate: number = 0;
+  private readonly PATRONS_CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes in milliseconds
+  private readonly NEROLI_CAMPAIGN_ID = '12771188';
+
+  private identityQuery = QueryBuilder.identity.setAttributes({
     user: ['email']
   });
+
+  // can add currently_entitled_tiers to addRelationships to find which tier the user is in
+  private memberQuery = QueryBuilder.campaignMembers
+    .addRelationships(['user']) // needed so we can grab id to compare with patreon_id
+    .setAttributes({
+      member: ['patron_status', 'pledge_relationship_start']
+    })
+    .setRequestOptions({ count: 1000 });
 
   async signup(params: {
     authorization_code: string;
@@ -30,10 +44,12 @@ export class PatreonProviderImpl extends AbstractProvider<PatreonUserClient> {
 
     const { access_token, refresh_token, expires_in_epoch } = token;
 
-    const { role, patreon_id, identifier } = await this.getPatronStatus({
+    const { patreon_id, identifier } = await this.getPatronId({
       token: access_token,
       redirect_uri
     });
+
+    const { role } = await this.isSupporter({ patreon_id, previousRole: preExistingUser?.role });
 
     const expiryDate = Number(expires_in_epoch);
 
@@ -82,6 +98,7 @@ export class PatreonProviderImpl extends AbstractProvider<PatreonUserClient> {
       avatar: existingUser.avatar
     };
   }
+
   async refresh(params: { refresh_token: string; redirect_uri: string }): Promise<RefreshResponse> {
     const { refresh_token, redirect_uri } = params;
 
@@ -98,42 +115,83 @@ export class PatreonProviderImpl extends AbstractProvider<PatreonUserClient> {
   }
 
   async verifyExistingUser(userHeader: UserHeader): Promise<DBUser> {
-    const { role, patreon_id } = await this.getPatronStatus({
+    const { patreon_id } = await this.getPatronId({
       token: userHeader.Authorization,
       redirect_uri: userHeader.Redirect
     });
 
-    return this.updateLastLogin(patreon_id, role);
+    const user = await UserDAO.get({ patreon_id });
+    const { role } = await this.isSupporter({ patreon_id, previousRole: user.role });
+
+    return this.updateLastLogin(user, role);
   }
 
-  async updateLastLogin(patreon_id: string, role: Roles): Promise<DBUser> {
-    const user = await UserDAO.get({ patreon_id });
+  async updateLastLogin(user: DBUser, role: Roles): Promise<DBUser> {
     return UserDAO.update({ ...user, last_login: new Date(), role });
   }
 
-  public async getPatronStatus(params: { token: string; redirect_uri: string }) {
+  public async getPatronId(params: {
+    token: string;
+    redirect_uri: string;
+  }): Promise<{ patreon_id: string; identifier: string }> {
     const { token, redirect_uri } = params;
-    const userData = await this.getUserClient(redirect_uri).fetchIdentity(this.identityQuery, {
-      token
-    });
+    const userData = simplify(
+      await this.getUserClient(redirect_uri).fetchIdentity(this.identityQuery, {
+        token
+      })
+    );
 
-    const membership = simplify(userData).memberships.at(0);
-    let role = Roles.Default;
-    let patronSince: string | undefined;
-    if (membership) {
-      const { patronStatus, pledgeRelationshipStart } = membership;
+    return {
+      patreon_id: userData.id,
+      identifier: userData.email
+    };
+  }
+
+  public async isSupporter(params: { patreon_id: string; previousRole?: Roles }): Promise<{
+    role: Roles;
+    patronSince: string | null;
+  }> {
+    const { patreon_id, previousRole } = params;
+    let patronSince: string | null = null;
+    let role = previousRole ?? Roles.Default;
+
+    await this.getPatrons();
+    const patron = this.patrons.get(patreon_id);
+
+    if (patron) {
+      const { patronStatus, pledgeRelationshipStart } = patron;
       if (patronStatus === 'active_patron') {
-        role = Roles.Supporter;
-        patronSince = pledgeRelationshipStart!;
+        // if user was default, we upgrade to supporter, but we dont downgrade admins
+        role = role === Roles.Default ? Roles.Supporter : role;
+        patronSince = pledgeRelationshipStart;
       }
     }
 
-    return {
-      patreon_id: userData.data.id,
-      role,
-      patronSince,
-      identifier: userData.data.attributes.email
-    };
+    return { role, patronSince };
+  }
+
+  private async getPatrons(): Promise<Map<string, Patron>> {
+    const now = Date.now();
+    if (this.patrons.size === 0 || now - this.lastPatronsUpdate > this.PATRONS_CACHE_TTL_MS) {
+      await this.updatePatrons();
+      this.lastPatronsUpdate = now;
+    }
+    return this.patrons;
+  }
+
+  private async updatePatrons(): Promise<Map<string, Patron>> {
+    const memberData = simplify(
+      await this.getCreatorClient().fetchCampaignMembers(this.NEROLI_CAMPAIGN_ID, this.memberQuery)
+    ).data;
+
+    for (const member of memberData) {
+      this.patrons.set(member.user.id, {
+        id: member.user.id,
+        patronStatus: member.patronStatus,
+        pledgeRelationshipStart: member.pledgeRelationshipStart
+      });
+    }
+    return this.patrons;
   }
 
   private getUserClient(redirect_uri: string) {
@@ -143,11 +201,27 @@ export class PatreonProviderImpl extends AbstractProvider<PatreonUserClient> {
           clientId: config.PATREON_CLIENT_ID,
           clientSecret: config.PATREON_CLIENT_SECRET,
           redirectUri: redirect_uri,
-          scopes: [PatreonOauthScope.IdentityEmail]
+          scopes: [PatreonOauthScope.Identity, PatreonOauthScope.IdentityEmail]
         }
       });
     }
     return this.client;
+  }
+
+  private getCreatorClient(): PatreonCreatorClient {
+    if (!this.creatorClient) {
+      this.creatorClient = new PatreonCreatorClient({
+        oauth: {
+          clientId: config.PATREON_CLIENT_ID,
+          clientSecret: config.PATREON_CLIENT_SECRET,
+          token: {
+            access_token: config.PATREON_CREATOR_ACCESS_TOKEN,
+            refresh_token: config.PATREON_CREATOR_REFRESH_TOKEN
+          }
+        }
+      });
+    }
+    return this.creatorClient;
   }
 }
 

--- a/backend/src/services/user-service/login-service/providers/patreon/patreon-types.ts
+++ b/backend/src/services/user-service/login-service/providers/patreon/patreon-types.ts
@@ -1,0 +1,7 @@
+export type PatronStatus = 'active_patron' | 'former_patron' | 'declined_patron';
+
+export type Patron = {
+  id: string;
+  patronStatus: PatronStatus | null;
+  pledgeRelationshipStart: string | null;
+};

--- a/backend/src/services/user-service/user-service.ts
+++ b/backend/src/services/user-service/user-service.ts
@@ -3,7 +3,7 @@ import { UserSettingsDAO } from '@src/database/dao/user-settings/user-settings-d
 import type { DBUser } from '@src/database/dao/user/user-dao.js';
 import { UserDAO } from '@src/database/dao/user/user-dao.js';
 import { PatreonProvider } from '@src/services/user-service/login-service/providers/patreon/patreon-provider.js';
-import type { IslandShortName, UpdateUserRequest, UserHeader, UserSettingsResponse } from 'sleepapi-common';
+import type { IslandShortName, UpdateUserRequest, UserSettingsResponse } from 'sleepapi-common';
 import { MAX_POT_SIZE } from 'sleepapi-common';
 
 export async function updateUser(user: DBUser, newSettings: Partial<UpdateUserRequest>) {
@@ -16,7 +16,7 @@ export async function deleteUser(user: DBUser) {
   UserDAO.delete({ id: user.id });
 }
 
-export async function getUserSettings(user: DBUser, userHeader: UserHeader): Promise<UserSettingsResponse> {
+export async function getUserSettings(user: DBUser): Promise<UserSettingsResponse> {
   const areaBonusesRaw = await UserAreaDAO.findMultiple({ fk_user_id: user.id });
 
   const areaBonuses: Partial<Record<IslandShortName, number>> = {};
@@ -24,11 +24,11 @@ export async function getUserSettings(user: DBUser, userHeader: UserHeader): Pro
     areaBonuses[areaBonus.area] = areaBonus.bonus;
   }
 
-  let supporterSince: string | undefined;
+  let supporterSince: string | null = null;
   if (user.patreon_id) {
-    const { role, patronSince } = await PatreonProvider.getPatronStatus({
-      token: userHeader.Authorization,
-      redirect_uri: userHeader.Redirect
+    const { role, patronSince } = await PatreonProvider.isSupporter({
+      patreon_id: user.patreon_id,
+      previousRole: user.role
     });
 
     await UserDAO.update({ ...user, role });

--- a/common/src/api/user/user-settings.ts
+++ b/common/src/api/user/user-settings.ts
@@ -11,5 +11,5 @@ export interface UserSettingsResponse {
   role: Roles;
   areaBonuses: GetAreaBonusesResponse;
   potSize: number;
-  supporterSince?: string;
+  supporterSince: string | null;
 }

--- a/frontend/src/assets/colors.scss
+++ b/frontend/src/assets/colors.scss
@@ -5,8 +5,9 @@ $secondary: #5e5a7f;
 $secondary-medium-dark: #5b577c;
 $secondary-dark: #43405b;
 $accent: #9a95c3;
-
 $strength: #ffb81f;
+
+$admin: #e63946;
 $supporter: #ffb81f;
 
 $nature-up: #ff683a;

--- a/frontend/src/assets/main.scss
+++ b/frontend/src/assets/main.scss
@@ -1,3 +1,4 @@
 @forward './variables';
 @forward './colors';
 @forward './typography';
+@forward './vuetify-overrides';

--- a/frontend/src/assets/vuetify-overrides.scss
+++ b/frontend/src/assets/vuetify-overrides.scss
@@ -1,0 +1,8 @@
+// TODO: use pre-defined font size variables
+.v-card {
+  font-size: 16px !important;
+
+  .v-card-text {
+    font-size: 16px !important;
+  }
+}

--- a/frontend/src/components/account/account-menu.vue
+++ b/frontend/src/components/account/account-menu.vue
@@ -9,7 +9,7 @@
           size="40"
           :class="borderClass"
         >
-          <img :src="userAvatar()" alt="User Profile Picture" height="24px" style="transform: scale(1.4)" />
+          <img :src="userAvatar()" alt="User Profile Picture" height="24px" style="transform: scale(1.5)" />
         </v-avatar>
         <v-icon v-else size="24">mdi-account-circle</v-icon>
       </v-btn>
@@ -86,9 +86,7 @@ export default defineComponent({
     menu: false
   }),
   async mounted() {
-    if (this.userStore.loggedIn) {
-      await this.userStore.syncUserSettings()
-    }
+    await this.userStore.syncUserSettings()
   },
   methods: {
     toggleMenu() {
@@ -111,9 +109,9 @@ export default defineComponent({
 }
 
 .admin-avatar {
-  border-color: var(--v-theme-primary) !important;
+  border-color: var(--v-theme-admin) !important;
   border-width: 2px;
-  box-shadow: 0 0 10px rgba(var(--v-theme-primary), 0.6);
+  box-shadow: 0 0 10px rgba(var(--v-theme-admin), 0.6);
 }
 
 .role-title {

--- a/frontend/src/components/donate/donate-menu.vue
+++ b/frontend/src/components/donate/donate-menu.vue
@@ -2,9 +2,7 @@
   <v-menu v-model="menu" :close-on-content-click="false" location="bottom" width="250px">
     <template #activator="{ props }">
       <v-btn v-bind="props" id="navBarIcon" icon>
-        <v-icon v-if="userStore.isAdmin || userStore.isSupporter" size="32" :color="userStore.roleData.color"
-          >mdi-heart</v-icon
-        >
+        <v-icon v-if="userStore.isAdminOrSupporter" size="32" :color="userStore.roleData.color">mdi-heart</v-icon>
         <v-icon v-else-if="!menu" size="32" color="pink">mdi-heart-outline</v-icon>
         <v-icon v-else class="animate-heart" size="32" color="pink">mdi-heart</v-icon>
       </v-btn>

--- a/frontend/src/components/nav-bar/nav-bar.vue
+++ b/frontend/src/components/nav-bar/nav-bar.vue
@@ -70,4 +70,10 @@ export default defineComponent({
   font-size: 16px;
   margin: -6px 0 0 5px;
 }
+
+@media (max-width: $desktop) {
+  .v-app-bar-title {
+    margin-inline-start: 0px !important;
+  }
+}
 </style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -28,8 +28,9 @@ async function initializeApp() {
       'secondary-dark': '#4A4765',
       surface: '#403D58',
       accent: '#9A95C3',
-
       strength: '#FFB81F',
+
+      admin: '#E63946',
       supporter: '#FFB81F',
 
       natureUp: 'FF683A',

--- a/frontend/src/pages/beta/beta.vue
+++ b/frontend/src/pages/beta/beta.vue
@@ -37,8 +37,8 @@
           </v-row>
           <v-row dense>
             <v-col cols="12" class="flex-center flex-column px-4">
-              To take advantage of our biggest new feature, saving your teams and Pokemon across devices, log in using
-              Google by clicking the Pokeball in the upper-right corner of the screen.
+              To take advantage of our biggest new feature, saving your teams and Pokemon across devices, log in by
+              clicking the Pokeball in the upper-right corner of the screen.
             </v-col>
           </v-row>
 

--- a/frontend/src/pages/profile-page.test.ts
+++ b/frontend/src/pages/profile-page.test.ts
@@ -1,4 +1,5 @@
 import ProfilePage from '@/pages/profile-page.vue'
+import { TimeUtils } from '@/services/utils/time-utils'
 import { useUserStore } from '@/stores/user-store'
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
@@ -53,7 +54,8 @@ describe('ProfilePage', () => {
       })
 
       it('displays supporter since date', () => {
-        const supporterSince = wrapper.findAll('.text-center').find((el) => el.text() === '2024-01-01')
+        const date = TimeUtils.extractDate(userStore.supporterSince!)
+        const supporterSince = wrapper.findAll('.text-center').find((el) => el.text() === date)
         expect(supporterSince?.classes()).toContain('text-supporter')
       })
 

--- a/frontend/src/pages/profile-page.vue
+++ b/frontend/src/pages/profile-page.vue
@@ -2,7 +2,11 @@
   <v-container style="max-width: 600px">
     <v-row>
       <v-col cols="12">
-        <v-card rounded="xl" class="pb-4 frosted-glass" :class="{ 'supporter-card': userStore.isSupporter }">
+        <v-card
+          rounded="xl"
+          class="pb-4 frosted-glass"
+          :class="{ 'supporter-card': userStore.isSupporter, 'admin-card': userStore.isAdmin }"
+        >
           <v-row class="pt-4">
             <v-col cols="12" class="flex-center text-h4"> Profile </v-col>
           </v-row>
@@ -50,31 +54,29 @@
               <span class="text-center font-weight-bold">Supporter status: </span>
             </v-col>
             <v-col cols="auto" class="flex-center">
-              <span :class="['text-center', userStore.isSupporter ? 'text-supporter' : 'text-grey']">{{
-                userStore.isSupporter ? 'Active' : 'Inactive'
+              <span :class="['text-center', userStore.supporterSince ? 'text-supporter' : 'text-grey']">{{
+                userStore.supporterSince ? 'Active' : 'Inactive'
               }}</span>
             </v-col>
           </v-row>
 
-          <v-row v-if="userStore.isSupporter" dense class="flex-center">
+          <v-row v-if="userStore.supporterSince" dense class="flex-center">
             <v-col cols="auto" class="flex-center">
               <span class="text-center font-weight-bold">Supporter since: </span>
             </v-col>
             <v-col cols="auto" class="flex-center">
-              <span :class="['text-center', userStore.isSupporter ? 'text-supporter' : 'text-grey']">{{
-                userStore.supporterSince
-              }}</span>
+              <span class="text-center text-supporter">{{ supporterSince }}</span>
             </v-col>
           </v-row>
         </v-card>
       </v-col>
     </v-row>
 
-    <v-row v-if="userStore.isSupporter">
+    <v-row v-if="userStore.isAdminOrSupporter">
       <v-col cols="12">
         <div class="d-flex align-center justify-center">
-          <v-icon class="mr-2" color="supporter">mdi-star</v-icon>
-          <span class="font-weight-bold text-supporter">Thank you for your support!</span>
+          <v-icon class="mr-2" :color="userStore.roleData.color">mdi-star</v-icon>
+          <span :class="['font-weight-bold', `text-${userStore.roleData.color}`]">Thank you for your support!</span>
         </div>
       </v-col>
     </v-row>
@@ -85,6 +87,7 @@
 import UserAvatar from '@/components/account/user-avatar.vue'
 import UserName from '@/components/account/user-name.vue'
 import { UserService } from '@/services/user/user-service'
+import { TimeUtils } from '@/services/utils/time-utils'
 import { useUserStore } from '@/stores/user-store'
 import { computed, defineComponent } from 'vue'
 
@@ -107,6 +110,11 @@ export default defineComponent({
     async updateAvatar(newAvatar: string) {
       await UserService.updateUser({ avatar: newAvatar })
     }
+  },
+  computed: {
+    supporterSince(): string | null {
+      return this.userStore.supporterSince && TimeUtils.extractDate(this.userStore.supporterSince)
+    }
   }
 })
 </script>
@@ -118,6 +126,15 @@ export default defineComponent({
 
   &:hover {
     box-shadow: 0 6px 25px rgba(var(--v-theme-strength), 0.4) !important;
+  }
+}
+
+.admin-card {
+  box-shadow: 0 4px 20px rgba(var(--v-theme-admin), 0.3) !important;
+  transition: box-shadow 0.3s ease;
+
+  &:hover {
+    box-shadow: 0 6px 25px rgba(var(--v-theme-admin), 0.4) !important;
   }
 }
 </style>

--- a/frontend/src/pages/settings/settings-page.test.ts
+++ b/frontend/src/pages/settings/settings-page.test.ts
@@ -1,9 +1,21 @@
 import { useBreakpoint } from '@/composables/use-breakpoint/use-breakpoint'
+import { RouteName } from '@/router/router'
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
+import type { RouteLocationNormalizedLoaded, Router } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import SettingsPage from './settings-page.vue'
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(() => ({
+    name: RouteName.SettingsGame
+  })),
+  useRouter: vi.fn(() => ({
+    push: vi.fn()
+  }))
+}))
 
 vi.mock('@/composables/use-breakpoint/use-breakpoint', () => ({
   useBreakpoint: vi.fn(() => ({
@@ -15,8 +27,14 @@ vi.mock('@/composables/use-breakpoint/use-breakpoint', () => ({
 
 describe('SettingsPage', () => {
   let wrapper: VueWrapper<InstanceType<typeof SettingsPage>>
+  const mockRouter = { push: vi.fn() } as unknown as Router
 
   beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useRoute).mockReturnValue({
+      name: RouteName.SettingsGame
+    } as unknown as RouteLocationNormalizedLoaded)
+    vi.mocked(useRouter).mockReturnValue(mockRouter)
     wrapper = mount(SettingsPage)
   })
 
@@ -32,7 +50,7 @@ describe('SettingsPage', () => {
     expect(wrapper.find('.v-tabs').exists()).toBe(false)
   })
 
-  it('renders mobile navigation when on mobile', async () => {
+  it('renders mobile navigation when on mobile', () => {
     vi.mocked(useBreakpoint).mockReturnValue({
       isMobile: ref(true),
       isLargeDesktop: ref(false),
@@ -44,37 +62,79 @@ describe('SettingsPage', () => {
     expect(wrapper.find('.v-tabs').exists()).toBe(true)
   })
 
-  it('starts with game tab active', () => {
-    expect(wrapper.vm.activeTab).toBe('game')
-  })
-
-  it('switches tabs correctly on desktop', async () => {
-    vi.mocked(useBreakpoint).mockReturnValue({
-      isMobile: ref(false),
-      isLargeDesktop: ref(true),
-      viewportWidth: ref(375)
-    })
-
-    wrapper = mount(SettingsPage)
-
-    const listItems = wrapper.findAll('.v-list-item')
-
-    await listItems[1].trigger('click')
-    expect(wrapper.vm.activeTab).toBe('account')
-
-    await listItems[2].trigger('click')
-    expect(wrapper.vm.activeTab).toBe('site')
-  })
-
   it('displays correct number of tabs', () => {
     const tabs = wrapper.vm.tabs
     expect(tabs).toHaveLength(3)
     expect(tabs.map((tab) => tab.value)).toEqual(['game', 'account', 'site'])
+    expect(wrapper.vm.activeTab).toBe('game')
   })
 
-  it('renders all settings components', () => {
-    expect(wrapper.html()).toContain('Game Settings')
-    expect(wrapper.html()).toContain('Account')
-    expect(wrapper.html()).toContain('Site')
+  it('calls router.push when tab is clicked', async () => {
+    // Ensure we're in desktop mode to see the list items
+    vi.mocked(useBreakpoint).mockReturnValue({
+      isMobile: ref(false),
+      isLargeDesktop: ref(true),
+      viewportWidth: ref(1024)
+    })
+    wrapper = mount(SettingsPage)
+
+    const listItems = wrapper.findAll('.v-list-item')
+    expect(listItems.length).toBeGreaterThan(0)
+
+    // Click on the account tab
+    await listItems[1].trigger('click')
+    expect(mockRouter.push).toHaveBeenCalledWith({ name: RouteName.SettingsAccount })
+  })
+
+  it('sets activeTab based on current route', () => {
+    // Game route
+    vi.mocked(useRoute).mockReturnValue({
+      name: RouteName.SettingsGame
+    } as unknown as RouteLocationNormalizedLoaded)
+    wrapper = mount(SettingsPage)
+    expect(wrapper.vm.activeTab).toBe('game')
+
+    // Account route
+    vi.mocked(useRoute).mockReturnValue({
+      name: RouteName.SettingsAccount
+    } as unknown as RouteLocationNormalizedLoaded)
+    wrapper = mount(SettingsPage)
+    expect(wrapper.vm.activeTab).toBe('account')
+
+    // Site route
+    vi.mocked(useRoute).mockReturnValue({
+      name: RouteName.SettingsSite
+    } as unknown as RouteLocationNormalizedLoaded)
+    wrapper = mount(SettingsPage)
+    expect(wrapper.vm.activeTab).toBe('site')
+  })
+
+  it('renders the correct component based on the route', () => {
+    // Game tab - shows GameSettings
+    vi.mocked(useRoute).mockReturnValue({
+      name: RouteName.SettingsGame
+    } as unknown as RouteLocationNormalizedLoaded)
+    wrapper = mount(SettingsPage)
+    expect(wrapper.findComponent({ name: 'GameSettings' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'AccountSettings' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'SiteSettings' }).exists()).toBe(false)
+
+    // Account tab - shows AccountSettings
+    vi.mocked(useRoute).mockReturnValue({
+      name: RouteName.SettingsAccount
+    } as unknown as RouteLocationNormalizedLoaded)
+    wrapper = mount(SettingsPage)
+    expect(wrapper.findComponent({ name: 'GameSettings' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'AccountSettings' }).exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'SiteSettings' }).exists()).toBe(false)
+
+    // Site tab - shows SiteSettings
+    vi.mocked(useRoute).mockReturnValue({
+      name: RouteName.SettingsSite
+    } as unknown as RouteLocationNormalizedLoaded)
+    wrapper = mount(SettingsPage)
+    expect(wrapper.findComponent({ name: 'GameSettings' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'AccountSettings' }).exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'SiteSettings' }).exists()).toBe(true)
   })
 })

--- a/frontend/src/pages/settings/settings-page.vue
+++ b/frontend/src/pages/settings/settings-page.vue
@@ -45,19 +45,9 @@
         </v-tab>
       </v-tabs>
 
-      <v-window v-model="activeTab">
-        <v-window-item value="game">
-          <GameSettings />
-        </v-window-item>
-
-        <v-window-item value="account">
-          <AccountSettings />
-        </v-window-item>
-
-        <v-window-item value="site">
-          <SiteSettings />
-        </v-window-item>
-      </v-window>
+      <GameSettings v-if="activeTab === 'game'" />
+      <AccountSettings v-if="activeTab === 'account'" />
+      <SiteSettings v-if="activeTab === 'site'" />
     </v-col>
   </v-row>
 </template>
@@ -67,9 +57,11 @@ import AccountSettings from '@/components/settings/account-settings/account-sett
 import GameSettings from '@/components/settings/game-settings/game-settings.vue'
 import SiteSettings from '@/components/settings/site-settings/site-settings.vue'
 import { useBreakpoint } from '@/composables/use-breakpoint/use-breakpoint'
+import { RouteName } from '@/router/router'
 import { useUserStore } from '@/stores/user-store'
 import { useVersionStore } from '@/stores/version-store/version-store'
 import { defineComponent } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 
 export default defineComponent({
   name: 'SettingsPage',
@@ -82,17 +74,32 @@ export default defineComponent({
     const userStore = useUserStore()
     const versionStore = useVersionStore()
     const { isMobile } = useBreakpoint()
+    const route = useRoute()
+    const router = useRouter()
 
-    return { userStore, versionStore, isMobile }
+    return { userStore, versionStore, isMobile, route, router }
   },
   data() {
     return {
-      activeTab: 'game',
       tabs: [
-        { value: 'game', text: 'Game' },
-        { value: 'account', text: 'Account', icon: 'mdi-account-circle' },
-        { value: 'site', text: 'Site', icon: 'mdi-web' }
+        { value: 'game', text: 'Game', routeName: RouteName.SettingsGame },
+        { value: 'account', text: 'Account', icon: 'mdi-account-circle', routeName: RouteName.SettingsAccount },
+        { value: 'site', text: 'Site', icon: 'mdi-web', routeName: RouteName.SettingsSite }
       ]
+    }
+  },
+  computed: {
+    activeTab: {
+      get() {
+        const routeName = this.route.name as string
+        return this.tabs.find((tab) => tab.routeName === routeName)?.value || 'game'
+      },
+      set(value: string) {
+        const tab = this.tabs.find((t) => t.value === value)
+        if (tab) {
+          this.router.push({ name: tab.routeName })
+        }
+      }
     }
   }
 })

--- a/frontend/src/router/router.ts
+++ b/frontend/src/router/router.ts
@@ -9,7 +9,13 @@ export enum RouteName {
   Compare = 'Compare',
   Recipes = 'Recipes',
 
+  // Settings
   Settings = 'Settings',
+  // tabs
+  SettingsGame = 'Game Settings',
+  SettingsAccount = 'Account Settings',
+  SettingsSite = 'Site Settings',
+
   Profile = 'Profile',
   // Friends = 'Friends',
 
@@ -73,7 +79,25 @@ const router = createRouter({
     {
       path: '/settings',
       name: RouteName.Settings,
-      component: SettingsPage
+      component: SettingsPage,
+      redirect: { name: RouteName.SettingsGame },
+      children: [
+        {
+          path: 'game',
+          name: RouteName.SettingsGame,
+          component: SettingsPage
+        },
+        {
+          path: 'account',
+          name: RouteName.SettingsAccount,
+          component: SettingsPage
+        },
+        {
+          path: 'site',
+          name: RouteName.SettingsSite,
+          component: SettingsPage
+        }
+      ]
     },
     {
       path: '/profile',

--- a/frontend/src/services/login/patreon-service.test.ts
+++ b/frontend/src/services/login/patreon-service.test.ts
@@ -33,35 +33,19 @@ describe('patreon-service', () => {
   })
 
   describe('getPatreonAuthCode', () => {
-    it('should construct the correct authorization URL with default scope', () => {
+    it('should construct the correct authorization URL', () => {
       getPatreonAuthCode(mockRoute)
 
       const expectedParams = new URLSearchParams({
         client_id: mockClientId,
         redirect_uri: PATREON_REDIRECT_URI,
         response_type: 'code',
-        scope: 'identity[email]',
+        scope: 'identity identity[email]',
         state: '/calculator'
       })
 
       const expectedUrl = `https://www.patreon.com/oauth2/authorize?${expectedParams.toString()}`
       expect(window.location.href).toEqual(expectedUrl)
-    })
-
-    it('should use custom scope when provided', () => {
-      const customScope = 'identity campaigns'
-      getPatreonAuthCode(mockRoute, customScope)
-
-      const expectedParams = new URLSearchParams({
-        client_id: mockClientId,
-        redirect_uri: 'http://localhost:3000/patreon',
-        response_type: 'code',
-        scope: customScope,
-        state: '/calculator'
-      })
-
-      const expectedUrl = `https://www.patreon.com/oauth2/authorize?${expectedParams.toString()}`
-      expect(window.location.href).toBe(expectedUrl)
     })
 
     it('should preserve query parameters in state when present in route', () => {
@@ -77,7 +61,7 @@ describe('patreon-service', () => {
         client_id: mockClientId,
         redirect_uri: 'http://localhost:3000/patreon',
         response_type: 'code',
-        scope: 'identity[email]',
+        scope: 'identity identity[email]',
         state: '/calculator?param=value'
       })
 

--- a/frontend/src/services/login/patreon-service.ts
+++ b/frontend/src/services/login/patreon-service.ts
@@ -3,7 +3,8 @@ import type { RouteLocationNormalizedLoaded } from 'vue-router'
 
 export const PATREON_REDIRECT_URI = `${window.location.origin}/patreon`
 
-export function getPatreonAuthCode(currentRoute: RouteLocationNormalizedLoaded, scope = 'identity[email]') {
+export function getPatreonAuthCode(currentRoute: RouteLocationNormalizedLoaded) {
+  const scope = 'identity identity[email]'
   const params = new URLSearchParams({
     client_id: import.meta.env.VITE_PATREON_CLIENT_ID,
     redirect_uri: PATREON_REDIRECT_URI,

--- a/frontend/src/services/utils/time-utils.test.ts
+++ b/frontend/src/services/utils/time-utils.test.ts
@@ -1,6 +1,6 @@
 import { TimeUtils } from '@/services/utils/time-utils'
 import type { Time } from 'sleepapi-common'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 describe('formatTime', () => {
   it('shall format seconds to hh:mm:ss', () => {
@@ -207,5 +207,72 @@ describe('calculateSleepDuration', () => {
         wakeup: '22:01'
       })
     ).toBe('1 minute')
+  })
+})
+
+describe('extractDate', () => {
+  const originalNavigator = global.navigator
+  const mockISOString = '2024-04-15T19:13:55.579+00:00'
+
+  afterEach(() => {
+    Object.defineProperty(global, 'navigator', {
+      value: originalNavigator,
+      configurable: true
+    })
+  })
+
+  it('formats date using default en-US locale', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { language: 'en-US' },
+      writable: true,
+      configurable: true
+    })
+
+    const result = TimeUtils.extractDate(mockISOString)
+    expect(result).toBe('April 15, 2024')
+  })
+
+  it('formats date using en-GB locale', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { language: 'en-GB' },
+      writable: true,
+      configurable: true
+    })
+
+    const result = TimeUtils.extractDate(mockISOString)
+    expect(result).toBe('15 April 2024')
+  })
+
+  it('formats date using de-DE locale', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { language: 'de-DE' },
+      writable: true,
+      configurable: true
+    })
+
+    const result = TimeUtils.extractDate(mockISOString)
+    expect(result).toBe('15. April 2024')
+  })
+
+  it('formats date using ja-JP locale', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { language: 'ja-JP' },
+      writable: true,
+      configurable: true
+    })
+
+    const result = TimeUtils.extractDate(mockISOString)
+    expect(result).toBe('2024年4月15日')
+  })
+
+  it('falls back to en-US when navigator.language is undefined', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { language: undefined },
+      writable: true,
+      configurable: true
+    })
+
+    const result = TimeUtils.extractDate(mockISOString)
+    expect(result).toBe('April 15, 2024')
   })
 })

--- a/frontend/src/services/utils/time-utils.ts
+++ b/frontend/src/services/utils/time-utils.ts
@@ -44,6 +44,16 @@ class TimeUtilsImpl {
     return `${hours !== '00' ? `${hours}h ` : ''}${minutes}m ${seconds}s`
   }
 
+  public extractDate(isoString: string): string {
+    const date = new Date(isoString)
+    const userLocale = navigator.language || 'en-US'
+    return new Intl.DateTimeFormat(userLocale, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    }).format(date)
+  }
+
   private calculateDurationInMinutes(params: { bedtime: string; wakeup: string }): number {
     const [bedHour, bedMinute] = params.bedtime.split(':').map(Number)
     const [wakeHour, wakeMinute] = params.wakeup.split(':').map(Number)

--- a/frontend/src/stores/avatar-store/avatar-store.ts
+++ b/frontend/src/stores/avatar-store/avatar-store.ts
@@ -34,7 +34,8 @@ export const useAvatarStore = defineStore('avatar', {
 
       const basePokemon = Object.entries(state.avatars)
         .filter(
-          ([name, path]) => path.includes(`${userStore.isSupporter ? '' : 'portrait'}/`) && !name.includes('shiny')
+          ([name, path]) =>
+            path.includes(`${userStore.isAdminOrSupporter ? '' : 'portrait'}/`) && !name.includes('shiny')
         )
         .map(([name, path]) => {
           const pokemon = findPokemon(name)

--- a/frontend/src/stores/user-store.test.ts
+++ b/frontend/src/stores/user-store.test.ts
@@ -268,29 +268,10 @@ describe('User Store', () => {
     })
 
     const userStore = useUserStore()
+    userStore.setInitialLoginData(commonMocks.loginResponse())
     await userStore.syncUserSettings()
 
     expect(UserService.getUserSettings).toHaveBeenCalled()
-    expect(userStore.$state).toMatchInlineSnapshot(`
-      {
-        "areaBonus": {
-          "cyan": 15,
-          "greengrass": 25,
-          "lapis": 35,
-          "powerplant": 45,
-          "snowdrop": 55,
-          "taupe": 65,
-        },
-        "auth": null,
-        "avatar": "synced avatar",
-        "externalId": null,
-        "friendCode": null,
-        "name": "synced name",
-        "potSize": 30,
-        "role": "admin",
-        "supporterSince": "2024-02-01",
-      }
-    `)
   })
 
   it('reset should return name and avatar to defaults', () => {

--- a/frontend/src/stores/user-store.ts
+++ b/frontend/src/stores/user-store.ts
@@ -21,7 +21,7 @@ export interface UserState {
   externalId: string | null
   friendCode: string | null
   auth: AuthProviders | null
-  role: Roles
+  role: Roles // TODO: make Role[]
   areaBonus: Record<IslandShortName, number>
   potSize: number
   supporterSince: string | null
@@ -82,11 +82,13 @@ export const useUserStore = defineStore('user', {
         this.areaBonus[area as IslandShortName] = bonus
       }
 
-      this.supporterSince = userSettings.supporterSince ?? null
+      this.supporterSince = userSettings.supporterSince
     },
     async syncUserSettings() {
-      const userSettings = await UserService.getUserSettings()
-      this.setUserSettings(userSettings)
+      if (this.loggedIn) {
+        const userSettings = await UserService.getUserSettings()
+        this.setUserSettings(userSettings)
+      }
     },
     async login(params: { authCode: string; provider: AuthProvider; originalRoute: string; redirectUri?: string }) {
       const { authCode, provider, originalRoute, redirectUri } = params
@@ -94,6 +96,7 @@ export const useUserStore = defineStore('user', {
 
       this.setInitialLoginData(loginResponse)
 
+      await this.syncUserSettings()
       router.push(originalRoute)
     },
     async unlinkProvider(provider: AuthProvider) {


### PR DESCRIPTION
This commit rewrites the entire oauth flow, including the Google implementation.

This adds Discord and Patreon oauth provider alternatives.

This adds linking of additional providers.

This adds tokens of appreciation for site supporters.

BREAKING CHANGE: Google client needs a redirect uri now and the API has been updated with new required headers.