### PR TITLE
feat: Allow subskill editing from member-results page

### DIFF
--- a/frontend/src/components/pokemon-input/menus/subskill-button.vue
+++ b/frontend/src/components/pokemon-input/menus/subskill-button.vue
@@ -1,5 +1,6 @@
 <template>
   <v-badge
+    v-if="subskill"
     class="w-100"
     location="top right"
     :offset-y="2"

--- a/frontend/src/components/pokemon-input/menus/subskill-menu.vue
+++ b/frontend/src/components/pokemon-input/menus/subskill-menu.vue
@@ -260,7 +260,8 @@ export default {
     }
   },
   mounted() {
-    this.selectedSubskills = this.currentSubskills
+    // deep copy to avoid mutating the original subskills without even saving
+    this.selectedSubskills = JSON.parse(JSON.stringify(this.currentSubskills))
   },
   methods: {
     subskillForLevel(subskillLevel: number): Subskill | undefined {


### PR DESCRIPTION
This commit enables you to modify a Pokémon's subskills directly from the team member results view.

Key changes:
- Subskill cards in `member-results.vue` are now clickable, opening the `subskill-menu.vue` dialog.
- `member-results.vue` now handles the logic for opening the dialog with the correct Pokémon's data and processes updates or cancellations from the menu.
- The `updateTeamMember` action in `team-store.ts` is called upon saving changes to persist them.
- Ensured that `subskill-menu.vue` works with a deep copy of subskill data to prevent immediate visual updates in the parent component before saving. This isolates changes to the dialog until explicitly saved or canceled.
- Corrected the `availableSubskills` prop passed to `subskill-menu.vue` to be the main `subskill` object from `sleepapi-common`, resolving an issue where subskill definitions were not being found.
- Added a `v-if` directive in `subskill-button.vue` for robustness, preventing rendering if its `subskill` prop is undefined.