### PR TITLE
feat: Add user setting to toggle random Pokémon names

### DIFF
--- a/backend/src/controllers/user/user.controller.ts
+++ b/backend/src/controllers/user/user.controller.ts
@@ -15,7 +15,7 @@ import {
   updateUser,
   upsertUserSettings
 } from '@src/services/user-service/user-service.js';
-import type { IslandShortName, PokemonInstanceWithMeta, UpdateUserRequest } from 'sleepapi-common';
+import type { IslandShortName, PokemonInstanceWithMeta, UpdateUserRequest, UserSettingsRequest } from 'sleepapi-common';
 
 export default class UserController {
   public async updateUser(user: DBUser, newSettings: Partial<UpdateUserRequest>) {
@@ -26,8 +26,8 @@ export default class UserController {
     return getUserSettings(user);
   }
 
-  public async upsertUserSettings(user: DBUser, potSize: number) {
-    return upsertUserSettings(user, potSize);
+  public async upsertUserSettings(user: DBUser, settings: UserSettingsRequest) {
+    return upsertUserSettings(user, settings);
   }
 
   public async deleteUser(user: DBUser) {

--- a/backend/src/database/dao/user-settings/user-settings-dao.ts
+++ b/backend/src/database/dao/user-settings/user-settings-dao.ts
@@ -7,7 +7,8 @@ export const DBUserSettingsSchema = Type.Composite([
   DBWithVersionedIdSchema,
   Type.Object({
     fk_user_id: Type.Number(),
-    pot_size: Type.Number({ minimum: MIN_POT_SIZE, maximum: MAX_POT_SIZE })
+    pot_size: Type.Number({ minimum: MIN_POT_SIZE, maximum: MAX_POT_SIZE }),
+    use_random_name: Type.Optional(Type.Boolean())
   })
 ]);
 

--- a/backend/src/database/migration/migrations/011_add_use_random_name_setting.js
+++ b/backend/src/database/migration/migrations/011_add_use_random_name_setting.js
@@ -1,0 +1,15 @@
+const Tables = {
+  UserSettings: 'user_settings',
+};
+
+export async function up(knex) {
+  await knex.schema.alterTable(Tables.UserSettings, (table) => {
+    table.boolean('use_random_name').notNullable().defaultTo(true);
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.alterTable(Tables.UserSettings, (table) => {
+    table.dropColumn('use_random_name');
+  });
+}

--- a/backend/src/services/user-service/user-service.ts
+++ b/backend/src/services/user-service/user-service.ts
@@ -1,9 +1,10 @@
 import { UserAreaDAO } from '@src/database/dao/user-area/user-area-dao.js';
+import type { DBUserSettings } from '@src/database/dao/user-settings/user-settings-dao.js';
 import { UserSettingsDAO } from '@src/database/dao/user-settings/user-settings-dao.js';
 import type { DBUser } from '@src/database/dao/user/user-dao.js';
 import { UserDAO } from '@src/database/dao/user/user-dao.js';
 import { PatreonProvider } from '@src/services/user-service/login-service/providers/patreon/patreon-provider.js';
-import type { IslandShortName, UpdateUserRequest, UserSettingsResponse } from 'sleepapi-common';
+import type { IslandShortName, UpdateUserRequest, UserSettingsRequest, UserSettingsResponse } from 'sleepapi-common';
 import { MAX_POT_SIZE } from 'sleepapi-common';
 
 export async function updateUser(user: DBUser, newSettings: Partial<UpdateUserRequest>) {
@@ -37,6 +38,7 @@ export async function getUserSettings(user: DBUser): Promise<UserSettingsRespons
 
   const userSettings = await UserSettingsDAO.find({ fk_user_id: user.id });
   const potSize = userSettings?.pot_size ?? MAX_POT_SIZE;
+  const useRandomName = userSettings?.use_random_name ?? true;
 
   return {
     name: user.name,
@@ -44,14 +46,33 @@ export async function getUserSettings(user: DBUser): Promise<UserSettingsRespons
     role: user.role,
     areaBonuses,
     potSize,
-    supporterSince
+    supporterSince,
+    useRandomName
   };
 }
 
-export async function upsertUserSettings(user: DBUser, potSize: number) {
-  await UserSettingsDAO.upsert({
-    updated: { fk_user_id: user.id, pot_size: potSize },
-    filter: { fk_user_id: user.id }
-  });
+export async function upsertUserSettings(user: DBUser, settings: UserSettingsRequest) {
+  const updatedSettings: Partial<Omit<DBUserSettings, 'id' | 'version'>> = {
+    fk_user_id: user.id
+  };
+
+  if (settings.potSize !== undefined) {
+    updatedSettings.pot_size = settings.potSize;
+  }
+
+  if (settings.useRandomName !== undefined) {
+    updatedSettings.use_random_name = settings.useRandomName;
+  }
+
+  // Avoid upserting if only fk_user_id is present (i.e. no actual settings are being changed)
+  // However, the UserSettingsRequest currently requires potSize, so this check might be redundant
+  // unless UserSettingsRequest changes. But it's good practice.
+  if (Object.keys(updatedSettings).length > 1) {
+    await UserSettingsDAO.upsert({
+      updated: updatedSettings,
+      filter: { fk_user_id: user.id }
+    });
+  }
+
   return;
 }

--- a/common/src/api/user/user-settings.ts
+++ b/common/src/api/user/user-settings.ts
@@ -3,6 +3,7 @@ import type { GetAreaBonusesResponse } from './user-area';
 
 export interface UserSettingsRequest {
   potSize: number;
+  useRandomName?: boolean;
 }
 
 export interface UserSettingsResponse {
@@ -12,4 +13,5 @@ export interface UserSettingsResponse {
   areaBonuses: GetAreaBonusesResponse;
   potSize: number;
   supporterSince: string | null;
+  useRandomName: boolean;
 }

--- a/frontend/src/components/pokemon-input/pokemon-name.vue
+++ b/frontend/src/components/pokemon-input/pokemon-name.vue
@@ -87,7 +87,7 @@ export default {
       }
     },
     randomizeName() {
-      return randomName(12, this.pokemonInstance.gender)
+      return randomName(this.pokemonInstance.pokemon, 12, this.pokemonInstance.gender)
     }
   }
 }

--- a/frontend/src/components/pokemon-input/pokemon-search.vue
+++ b/frontend/src/components/pokemon-input/pokemon-search.vue
@@ -54,7 +54,7 @@ export default {
 
       const pokemonInstance: PokemonInstanceExt = {
         pokemon: pkmn,
-        name: randomName(12, gender),
+        name: randomName(pkmn, 12, gender),
         level: 60,
         ribbon: 0,
         carrySize: CarrySizeUtils.maxCarrySize(pkmn),

--- a/frontend/src/components/settings/site-settings/site-settings.vue
+++ b/frontend/src/components/settings/site-settings/site-settings.vue
@@ -10,6 +10,20 @@
       </p>
     </SettingsCard>
 
+    <SettingsCard title="Pokémon Name Generation" icon="mdi-dice-multiple">
+      <p class="mb-2">Control how Pokémon names are generated when they are first acquired.</p>
+      <v-switch
+        v-model="useRandomPokemonNames"
+        label="Use Random Pokémon Names"
+        color="primary"
+        inset
+      ></v-switch>
+      <p class="fine-print">
+        If enabled, newly acquired Pokémon will be given a random nickname. If disabled, they will use their default
+        species name.
+      </p>
+    </SettingsCard>
+
     <SettingsCard title="Cache Settings" icon="mdi-cached">
       <p class="mb-4">
         In case of issues please try clearing the cache. If that doesn't work, contact the developers and attach the
@@ -22,10 +36,34 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { clearCacheKeepLogin } from '@/stores/store-service'
+import { useUserStore } from '@/stores/user-store'
+import { UserService } from '@/services/user/user-service'
 import { useVersionStore } from '@/stores/version-store/version-store'
 import SettingsCard from '../settings-card.vue'
+
 const versionStore = useVersionStore()
+const userStore = useUserStore()
+
+const useRandomPokemonNames = computed({
+  get: () => userStore.useRandomName,
+  set: async (newValue: boolean) => {
+    try {
+      // Optimistically update the store for immediate UI feedback
+      // The store might be updated again if there's a sync mechanism after API call
+      userStore.useRandomName = newValue 
+      await UserService.upsertUserSettings({ useRandomName: newValue, potSize: userStore.potSize })
+      // Optionally, trigger a sync or rely on existing mechanisms to ensure store consistency
+      // await userStore.syncUserSettings(); 
+    } catch (error) {
+      console.error('Failed to update useRandomName setting:', error)
+      // Revert optimistic update if API call fails
+      userStore.useRandomName = !newValue 
+      // TODO: Show user-friendly error notification
+    }
+  }
+})
 
 function clear() {
   clearCacheKeepLogin()

--- a/frontend/src/pages/compare/comparison-page.vue
+++ b/frontend/src/pages/compare/comparison-page.vue
@@ -197,7 +197,7 @@ export default defineComponent({
           version: 0,
           saved: false,
           externalId: uuid.v4(),
-          name: randomName(12, pokemonInstance.gender)
+          name: randomName(pokemonInstance.pokemon, 12, pokemonInstance.gender)
         }
         this.comparisonStore.addMember({
           ...copiedProduction,

--- a/frontend/src/services/user/user-service.ts
+++ b/frontend/src/services/user/user-service.ts
@@ -61,8 +61,8 @@ class UserServiceImpl {
     return response.data
   }
 
-  public async upsertUserSettings(potSize: number) {
-    const response = await serverAxios.put<UserSettingsRequest>('user/settings', { potSize })
+  public async upsertUserSettings(settings: UserSettingsRequest) {
+    const response = await serverAxios.put<UserSettingsRequest>('user/settings', settings)
     return response.data
   }
 }

--- a/frontend/src/services/utils/name-utils.ts
+++ b/frontend/src/services/utils/name-utils.ts
@@ -1,7 +1,14 @@
+import { useUserStore } from '@/stores/user-store'
 import { faker } from '@faker-js/faker/locale/en'
-import type { PokemonGender } from 'sleepapi-common'
+import type { Pokemon, PokemonGender } from 'sleepapi-common' // Assuming 'Pokemon' is the correct type
 
-export function randomName(maxLength: number, gender: PokemonGender) {
+export function randomName(pokemon: Pokemon, maxLength: number, gender: PokemonGender): string {
+  const userStore = useUserStore()
+
+  if (!userStore.useRandomName) {
+    return pokemon.displayName.slice(0, maxLength)
+  }
+
   let name = faker.person.firstName(gender)
   while (name.length > maxLength) {
     name = faker.person.firstName(gender)

--- a/frontend/src/stores/user-store.ts
+++ b/frontend/src/stores/user-store.ts
@@ -25,6 +25,7 @@ export interface UserState {
   areaBonus: Record<IslandShortName, number>
   potSize: number
   supporterSince: string | null
+  useRandomName: boolean;
 }
 
 export const useUserStore = defineStore('user', {
@@ -38,7 +39,8 @@ export const useUserStore = defineStore('user', {
       areaBonus: Object.fromEntries(ISLANDS.map((island) => [island.shortName, 0])) as Record<IslandShortName, number>,
       potSize: MAX_POT_SIZE,
       auth: null,
-      supporterSince: null
+      supporterSince: null,
+      useRandomName: true
     }
   },
   getters: {
@@ -85,6 +87,7 @@ export const useUserStore = defineStore('user', {
       this.avatar = userSettings.avatar
       this.role = userSettings.role
       this.potSize = userSettings.potSize
+      this.useRandomName = userSettings.useRandomName;
 
       for (const [area, bonus] of Object.entries(userSettings.areaBonuses)) {
         this.areaBonus[area as IslandShortName] = bonus


### PR DESCRIPTION
This commit introduces a new user setting allowing you to choose between generating random names for your Pokémon or using the Pokémon's default display name.

Key changes:

Backend:
- Added a database migration (011_add_use_random_name_setting.js) to introduce a `use_random_name` (boolean, default true) column to the `user_settings` table.
- Updated UserSettingsDAO, backend UserService, and UserController to support reading and writing this new setting.
- Updated relevant DTOs in `common/src/api/user/user-settings.ts`.

Frontend:
- Modified the frontend UserService and UserStore to manage the `useRandomName` setting.
- Added a toggle switch in the Site Settings page (`frontend/src/components/settings/site-settings/site-settings.vue`) for you to control this preference.
- Updated the core name generation logic in `frontend/src/services/utils/name-utils.ts`. The `randomName` function now accepts the full Pokémon object and conditionally generates a name based on your setting.
- Adjusted calls to `randomName` in `pokemon-search.vue`, `comparison-page.vue`, and `pokemon-name.vue` to pass the Pokémon object.