### PR TITLE
chore(testing): Add type-watch to common

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -19,7 +19,8 @@
     "build-rollup": "rollup --config rollup.config.mjs",
     "build-watch": "npm run clean && npm run build-rollup -- --watch",
     "test": "vitest --run --coverage",
-    "test-watch": "vitest --changed"
+    "test-watch": "vitest --changed",
+    "type-watch": "bun x tsc --noEmit --watch"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.3",


### PR DESCRIPTION
This npm script helps catch type errors in tests. It's copied from the frontend and backend.