### PR TITLE
feat(iv graph) Use mon's skill level to compare

### DIFF
--- a/backend/src/services/solve/utils/solve-utils.ts
+++ b/backend/src/services/solve/utils/solve-utils.ts
@@ -182,7 +182,9 @@ export function pokedexToMembers(params: { pokedex: Pokedex; level: number; camp
     const pokemonWithIngredients: PokemonWithIngredients = { pokemon: pkmn, ingredientList: AAA };
 
     const isSupportSkillMon = pkmn.specialty === 'skill' && INGREDIENT_SUPPORT_MAINSKILLS_SET.has(pkmn.skill.name);
-    const optimalSettings: Optimal = isSupportSkillMon ? Optimal.skill(pkmn, 4) : Optimal.ingredient(pkmn, 4);
+    const optimalSettings: Optimal = isSupportSkillMon
+      ? Optimal.skill(pkmn, 4, pkmn.skill.maxLevel)
+      : Optimal.ingredient(pkmn, 4, pkmn.skill.maxLevel);
     const settings = Optimal.toMemberSettings({ stats: optimalSettings, level, externalId: pkmn.name });
 
     // TODO: this should probably be moved to member-state constructor

--- a/common/src/domain/optimal/optimal.test.ts
+++ b/common/src/domain/optimal/optimal.test.ts
@@ -46,6 +46,24 @@ describe('Optimal', () => {
     });
   });
 
+  it('should use the skill level provided', () => {
+    const optimalBerry = Optimal.berry(mockedPokemon, 2, 4);
+
+    expect(optimalBerry).toEqual({
+      subskills: [
+        { level: 10, subskill: BERRY_FINDING_S },
+        { level: 25, subskill: HELPING_SPEED_M },
+        { level: 50, subskill: HELPING_SPEED_S },
+        { level: 75, subskill: HELPING_BONUS },
+        { level: 100, subskill: SKILL_TRIGGER_M }
+      ],
+      nature: ADAMANT,
+      skillLevel: 4,
+      carrySize: mockedPokemon.carrySize,
+      ribbon: 2
+    });
+  });
+
   it('should return correct optimal setup for berry production', () => {
     const optimalBerry = Optimal.berry(mockedPokemon);
 

--- a/common/src/domain/optimal/optimal.ts
+++ b/common/src/domain/optimal/optimal.ts
@@ -24,7 +24,7 @@ export interface Optimal {
 }
 
 class OptimalImpl {
-  public berry(pokemon: Pokemon, ribbon?: number): Optimal {
+  public berry(pokemon: Pokemon, ribbon?: number, skillLevel?: number): Optimal {
     return {
       subskills: [
         { level: 10, subskill: BERRY_FINDING_S },
@@ -34,13 +34,13 @@ class OptimalImpl {
         { level: 100, subskill: SKILL_TRIGGER_M }
       ],
       nature: ADAMANT,
-      skillLevel: pokemon.skill.maxLevel,
+      skillLevel: skillLevel ?? pokemon.skill.maxLevel,
       carrySize: pokemon.carrySize,
       ribbon: ribbon ?? 4
     };
   }
 
-  public ingredient(pokemon: Pokemon, ribbon?: number): Optimal {
+  public ingredient(pokemon: Pokemon, ribbon?: number, skillLevel?: number): Optimal {
     return {
       subskills: [
         { level: 10, subskill: INGREDIENT_FINDER_M },
@@ -50,12 +50,13 @@ class OptimalImpl {
         { level: 100, subskill: HELPING_SPEED_S }
       ],
       nature: QUIET,
-      skillLevel: pokemon.skill.maxLevel,
+      skillLevel: skillLevel ?? pokemon.skill.maxLevel,
       carrySize: pokemon.carrySize + pokemon.previousEvolutions * 5,
       ribbon: ribbon ?? 4
     };
   }
-  public skill(pokemon: Pokemon, ribbon?: number): Optimal {
+
+  public skill(pokemon: Pokemon, ribbon?: number, skillLevel?: number): Optimal {
     return {
       subskills: [
         { level: 10, subskill: SKILL_TRIGGER_M },
@@ -65,7 +66,7 @@ class OptimalImpl {
         { level: 100, subskill: HELPING_BONUS }
       ],
       nature: CAREFUL,
-      skillLevel: pokemon.skill.maxLevel,
+      skillLevel: skillLevel ?? pokemon.skill.maxLevel,
       carrySize: pokemon.carrySize + pokemon.previousEvolutions * 5,
       ribbon: ribbon ?? 4
     };

--- a/frontend/src/services/team/team-service.ts
+++ b/frontend/src/services/team/team-service.ts
@@ -185,17 +185,17 @@ class TeamServiceImpl {
 
     const berrySetup: PokemonInstanceIdentity = PokemonInstanceUtils.toPokemonInstanceIdentity({
       ...currentMember,
-      ...Optimal.berry(currentMember.pokemon, currentMember.ribbon),
+      ...Optimal.berry(currentMember.pokemon, currentMember.ribbon, currentMember.skillLevel),
       externalId: uuid.v4()
     })
     const ingredientSetup: PokemonInstanceIdentity = PokemonInstanceUtils.toPokemonInstanceIdentity({
       ...currentMember,
-      ...Optimal.ingredient(currentMember.pokemon, currentMember.ribbon),
+      ...Optimal.ingredient(currentMember.pokemon, currentMember.ribbon, currentMember.skillLevel),
       externalId: uuid.v4()
     })
     const skillSetup: PokemonInstanceIdentity = PokemonInstanceUtils.toPokemonInstanceIdentity({
       ...currentMember,
-      ...Optimal.skill(currentMember.pokemon, currentMember.ribbon),
+      ...Optimal.skill(currentMember.pokemon, currentMember.ribbon, currentMember.skillLevel),
       externalId: uuid.v4()
     })
 


### PR DESCRIPTION
Rather than using max skill levels for optimal mons, use the same skill level as the user entered.

Sleep API will still use the max skill level, because that's also used for the tier lists, and I think it makes sense for tier lists to use fully-invested mons.