### PR TITLE
Base pokemon util function

### DIFF
--- a/common/src/types/pokemon/all-pokemon.ts
+++ b/common/src/types/pokemon/all-pokemon.ts
@@ -1,3 +1,4 @@
+import { basePokemon } from '../../utils';
 import { toSeconds } from '../../utils/time-utils/frequency-utils';
 import { WIKI } from '../berry/berries';
 import { GENDER_UNKNOWN } from '../gender';
@@ -15,7 +16,7 @@ import {
 import { ChargeStrengthMBadDreams } from '../mainskill/mainskills/charge-strength-m-bad-dreams';
 import type { Pokemon } from './pokemon';
 
-export const DARKRAI: Pokemon = {
+export const DARKRAI: Pokemon = basePokemon({
   name: 'DARKRAI',
   displayName: 'Darkrai',
   pokedexNumber: 491,
@@ -61,7 +62,7 @@ export const DARKRAI: Pokemon = {
     { amount: 4, ingredient: ROUSING_COFFEE }
   ],
   skill: ChargeStrengthMBadDreams
-};
+});
 
 export const OPTIMAL_ALL_SPECIALISTS: Pokemon[] = [DARKRAI];
 export const INFERIOR_ALL_SPECIALISTS: Pokemon[] = [];

--- a/common/src/types/pokemon/all-pokemon.ts
+++ b/common/src/types/pokemon/all-pokemon.ts
@@ -17,7 +17,6 @@ import { ChargeStrengthMBadDreams } from '../mainskill/mainskills/charge-strengt
 import type { Pokemon } from './pokemon';
 
 export const DARKRAI: Pokemon = basePokemon({
-  name: 'DARKRAI',
   displayName: 'Darkrai',
   pokedexNumber: 491,
   specialty: 'all',

--- a/common/src/types/pokemon/berry-pokemon.ts
+++ b/common/src/types/pokemon/berry-pokemon.ts
@@ -57,7 +57,6 @@ import {
 import type { Pokemon } from './pokemon';
 
 export const CATERPIE: Pokemon = basePokemon({
-  name: 'CATERPIE',
   displayName: 'Caterpie',
   pokedexNumber: 10,
   specialty: 'berry',
@@ -105,7 +104,6 @@ export const BUTTERFREE: Pokemon = {
 };
 
 export const RATTATA: Pokemon = basePokemon({
-  name: 'RATTATA',
   displayName: 'Rattata',
   pokedexNumber: 19,
   specialty: 'berry',
@@ -142,7 +140,6 @@ export const RATICATE: Pokemon = {
 };
 
 export const EKANS: Pokemon = basePokemon({
-  name: 'EKANS',
   displayName: 'Ekans',
   pokedexNumber: 23,
   specialty: 'berry',
@@ -179,7 +176,6 @@ export const ARBOK: Pokemon = {
 };
 
 export const PIKACHU: Pokemon = basePokemon({
-  name: 'PIKACHU',
   displayName: 'Pikachu',
   pokedexNumber: 25,
   specialty: 'berry',
@@ -205,7 +201,6 @@ export const PIKACHU: Pokemon = basePokemon({
 });
 
 export const PIKACHU_HALLOWEEN: Pokemon = basePokemon({
-  name: 'PIKACHU_HALLOWEEN',
   displayName: 'Pikachu (Halloween)',
   pokedexNumber: 25,
   specialty: 'berry',
@@ -242,7 +237,6 @@ export const RAICHU: Pokemon = {
 };
 
 export const CLEFAIRY: Pokemon = basePokemon({
-  name: 'CLEFAIRY',
   displayName: 'Clefairy',
   pokedexNumber: 35,
   specialty: 'berry',
@@ -279,7 +273,6 @@ export const CLEFABLE: Pokemon = {
 };
 
 export const VULPIX: Pokemon = basePokemon({
-  name: 'VULPIX',
   displayName: 'Vulpix',
   pokedexNumber: 37,
   specialty: 'berry',
@@ -305,7 +298,6 @@ export const VULPIX: Pokemon = basePokemon({
 });
 
 export const VULPIX_ALOLAN: Pokemon = basePokemon({
-  name: 'VULPIX_ALOLAN',
   displayName: 'Vulpix (Alolan Form)',
   pokedexNumber: 37,
   specialty: 'berry',
@@ -353,7 +345,6 @@ export const NINETALES_ALOLAN: Pokemon = {
 };
 
 export const MANKEY: Pokemon = basePokemon({
-  name: 'MANKEY',
   displayName: 'Mankey',
   pokedexNumber: 56,
   specialty: 'berry',
@@ -390,7 +381,6 @@ export const PRIMEAPE: Pokemon = {
 };
 
 export const DODUO: Pokemon = basePokemon({
-  name: 'DODUO',
   displayName: 'Doduo',
   pokedexNumber: 84,
   specialty: 'berry',
@@ -427,7 +417,6 @@ export const DODRIO: Pokemon = {
 };
 
 export const ONIX: Pokemon = basePokemon({
-  name: 'ONIX',
   displayName: 'Onix',
   pokedexNumber: 95,
   specialty: 'berry',
@@ -453,7 +442,6 @@ export const ONIX: Pokemon = basePokemon({
 });
 
 export const CUBONE: Pokemon = basePokemon({
-  name: 'CUBONE',
   displayName: 'Cubone',
   pokedexNumber: 104,
   specialty: 'berry',
@@ -489,7 +477,6 @@ export const MAROWAK: Pokemon = {
 };
 
 export const EEVEE_HOLIDAY: Pokemon = basePokemon({
-  name: 'EEVEE_HOLIDAY',
   displayName: 'Eevee (Holiday)',
   pokedexNumber: 133,
   specialty: 'berry',
@@ -515,7 +502,6 @@ export const EEVEE_HOLIDAY: Pokemon = basePokemon({
 });
 
 export const CHIKORITA: Pokemon = basePokemon({
-  name: 'CHIKORITA',
   displayName: 'Chikorita',
   pokedexNumber: 152,
   specialty: 'berry',
@@ -563,7 +549,6 @@ export const MEGANIUM: Pokemon = {
 };
 
 export const CYNDAQUIL: Pokemon = basePokemon({
-  name: 'CYNDAQUIL',
   displayName: 'Cyndaquil',
   pokedexNumber: 155,
   specialty: 'berry',
@@ -611,7 +596,6 @@ export const TYPHLOSION: Pokemon = {
 };
 
 export const TOTODILE: Pokemon = basePokemon({
-  name: 'TOTODILE',
   displayName: 'Totodile',
   pokedexNumber: 158,
   specialty: 'berry',
@@ -692,7 +676,6 @@ export const STEELIX: Pokemon = {
 };
 
 export const SNEASEL: Pokemon = basePokemon({
-  name: 'SNEASEL',
   displayName: 'Sneasel',
   pokedexNumber: 215,
   specialty: 'berry',
@@ -718,7 +701,6 @@ export const SNEASEL: Pokemon = basePokemon({
 });
 
 export const HOUNDOUR: Pokemon = basePokemon({
-  name: 'HOUNDOUR',
   displayName: 'Houndour',
   pokedexNumber: 228,
   specialty: 'berry',
@@ -755,7 +737,6 @@ export const HOUNDOOM: Pokemon = {
 };
 
 export const SLAKOTH: Pokemon = basePokemon({
-  name: 'SLAKOTH',
   displayName: 'Slakoth',
   pokedexNumber: 287,
   specialty: 'berry',
@@ -803,7 +784,6 @@ export const SLAKING: Pokemon = {
 };
 
 export const SWABLU: Pokemon = basePokemon({
-  name: 'SWABLU',
   displayName: 'Swablu',
   pokedexNumber: 333,
   specialty: 'berry',
@@ -841,7 +821,6 @@ export const ALTARIA: Pokemon = {
 };
 
 export const SHUPPET: Pokemon = basePokemon({
-  name: 'SHUPPET',
   displayName: 'Shuppet',
   pokedexNumber: 353,
   specialty: 'berry',
@@ -878,7 +857,6 @@ export const BANETTE: Pokemon = {
 };
 
 export const SPHEAL: Pokemon = basePokemon({
-  name: 'SPHEAL',
   displayName: 'Spheal',
   pokedexNumber: 363,
   specialty: 'berry',
@@ -937,7 +915,6 @@ export const WEAVILE: Pokemon = {
 };
 
 export const MUNNA: Pokemon = basePokemon({
-  name: 'MUNNA',
   displayName: 'Munna',
   pokedexNumber: 517,
   specialty: 'berry',

--- a/common/src/types/pokemon/berry-pokemon.ts
+++ b/common/src/types/pokemon/berry-pokemon.ts
@@ -68,6 +68,9 @@ export const CATERPIE: Pokemon = basePokemon({
   carrySize: 11,
   previousEvolutions: 0,
   remainingEvolutions: 2,
+  ingredientA: HONEY,
+  ingredientB: SNOOZY_TOMATO,
+  ingredientC: GREENGRASS_SOYBEANS,
   ingredient0: [{ amount: 1, ingredient: HONEY }],
   ingredient30: [
     { amount: 2, ingredient: HONEY },

--- a/common/src/types/pokemon/berry-pokemon.ts
+++ b/common/src/types/pokemon/berry-pokemon.ts
@@ -1,3 +1,4 @@
+import { basePokemon } from '../../utils';
 import { evolvesFrom, evolvesInto } from '../../utils/pokemon-utils/evolution-utils';
 import { toSeconds } from '../../utils/time-utils/frequency-utils';
 import {
@@ -55,7 +56,7 @@ import {
 
 import type { Pokemon } from './pokemon';
 
-export const CATERPIE: Pokemon = {
+export const CATERPIE: Pokemon = basePokemon({
   name: 'CATERPIE',
   displayName: 'Caterpie',
   pokedexNumber: 10,
@@ -79,7 +80,7 @@ export const CATERPIE: Pokemon = {
     { amount: 4, ingredient: GREENGRASS_SOYBEANS }
   ],
   skill: IngredientMagnetS
-};
+});
 
 export const METAPOD: Pokemon = {
   ...evolvesFrom(CATERPIE),
@@ -103,7 +104,7 @@ export const BUTTERFREE: Pokemon = {
   carrySize: 21
 };
 
-export const RATTATA: Pokemon = {
+export const RATTATA: Pokemon = basePokemon({
   name: 'RATTATA',
   displayName: 'Rattata',
   pokedexNumber: 19,
@@ -127,7 +128,7 @@ export const RATTATA: Pokemon = {
     { amount: 3, ingredient: BEAN_SAUSAGE }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const RATICATE: Pokemon = {
   ...evolvesFrom(RATTATA),
@@ -140,7 +141,7 @@ export const RATICATE: Pokemon = {
   carrySize: 16
 };
 
-export const EKANS: Pokemon = {
+export const EKANS: Pokemon = basePokemon({
   name: 'EKANS',
   displayName: 'Ekans',
   pokedexNumber: 23,
@@ -164,7 +165,7 @@ export const EKANS: Pokemon = {
     { amount: 3, ingredient: FIERY_HERB }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const ARBOK: Pokemon = {
   ...evolvesFrom(EKANS),
@@ -177,7 +178,7 @@ export const ARBOK: Pokemon = {
   carrySize: 14
 };
 
-export const PIKACHU: Pokemon = {
+export const PIKACHU: Pokemon = basePokemon({
   name: 'PIKACHU',
   displayName: 'Pikachu',
   pokedexNumber: 25,
@@ -201,9 +202,9 @@ export const PIKACHU: Pokemon = {
     { amount: 3, ingredient: WARMING_GINGER }
   ],
   skill: ChargeStrengthS
-};
+});
 
-export const PIKACHU_HALLOWEEN: Pokemon = {
+export const PIKACHU_HALLOWEEN: Pokemon = basePokemon({
   name: 'PIKACHU_HALLOWEEN',
   displayName: 'Pikachu (Halloween)',
   pokedexNumber: 25,
@@ -227,7 +228,7 @@ export const PIKACHU_HALLOWEEN: Pokemon = {
     { amount: 3, ingredient: WARMING_GINGER }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const RAICHU: Pokemon = {
   ...evolvesFrom(PIKACHU),
@@ -240,7 +241,7 @@ export const RAICHU: Pokemon = {
   carrySize: 21
 };
 
-export const CLEFAIRY: Pokemon = {
+export const CLEFAIRY: Pokemon = basePokemon({
   name: 'CLEFAIRY',
   displayName: 'Clefairy',
   pokedexNumber: 35,
@@ -264,7 +265,7 @@ export const CLEFAIRY: Pokemon = {
     { amount: 3, ingredient: GREENGRASS_SOYBEANS }
   ],
   skill: Metronome
-};
+});
 
 export const CLEFABLE: Pokemon = {
   ...evolvesFrom(CLEFAIRY),
@@ -277,7 +278,7 @@ export const CLEFABLE: Pokemon = {
   carrySize: 24
 };
 
-export const VULPIX: Pokemon = {
+export const VULPIX: Pokemon = basePokemon({
   name: 'VULPIX',
   displayName: 'Vulpix',
   pokedexNumber: 37,
@@ -301,9 +302,9 @@ export const VULPIX: Pokemon = {
     { amount: 3, ingredient: SOFT_POTATO }
   ],
   skill: EnergizingCheerS
-};
+});
 
-export const VULPIX_ALOLAN: Pokemon = {
+export const VULPIX_ALOLAN: Pokemon = basePokemon({
   name: 'VULPIX_ALOLAN',
   displayName: 'Vulpix (Alolan Form)',
   pokedexNumber: 37,
@@ -327,7 +328,7 @@ export const VULPIX_ALOLAN: Pokemon = {
     { amount: 3, ingredient: SOFT_POTATO }
   ],
   skill: ExtraHelpfulS
-};
+});
 
 export const NINETALES: Pokemon = {
   ...evolvesFrom(VULPIX),
@@ -351,7 +352,7 @@ export const NINETALES_ALOLAN: Pokemon = {
   carrySize: 20
 };
 
-export const MANKEY: Pokemon = {
+export const MANKEY: Pokemon = basePokemon({
   name: 'MANKEY',
   displayName: 'Mankey',
   pokedexNumber: 56,
@@ -375,7 +376,7 @@ export const MANKEY: Pokemon = {
     { amount: 4, ingredient: HONEY }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const PRIMEAPE: Pokemon = {
   ...evolvesFrom(MANKEY),
@@ -388,7 +389,7 @@ export const PRIMEAPE: Pokemon = {
   carrySize: 17
 };
 
-export const DODUO: Pokemon = {
+export const DODUO: Pokemon = basePokemon({
   name: 'DODUO',
   displayName: 'Doduo',
   pokedexNumber: 84,
@@ -412,7 +413,7 @@ export const DODUO: Pokemon = {
     { amount: 3, ingredient: BEAN_SAUSAGE }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const DODRIO: Pokemon = {
   ...evolvesFrom(DODUO),
@@ -425,7 +426,7 @@ export const DODRIO: Pokemon = {
   carrySize: 21
 };
 
-export const ONIX: Pokemon = {
+export const ONIX: Pokemon = basePokemon({
   name: 'ONIX',
   displayName: 'Onix',
   pokedexNumber: 95,
@@ -449,9 +450,9 @@ export const ONIX: Pokemon = {
     { amount: 3, ingredient: SOFT_POTATO }
   ],
   skill: IngredientMagnetS
-};
+});
 
-export const CUBONE: Pokemon = {
+export const CUBONE: Pokemon = basePokemon({
   name: 'CUBONE',
   displayName: 'Cubone',
   pokedexNumber: 104,
@@ -474,7 +475,7 @@ export const CUBONE: Pokemon = {
     { amount: 3, ingredient: SOOTHING_CACAO }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const MAROWAK: Pokemon = {
   ...evolvesFrom(CUBONE),
@@ -487,7 +488,7 @@ export const MAROWAK: Pokemon = {
   carrySize: 15
 };
 
-export const EEVEE_HOLIDAY: Pokemon = {
+export const EEVEE_HOLIDAY: Pokemon = basePokemon({
   name: 'EEVEE_HOLIDAY',
   displayName: 'Eevee (Holiday)',
   pokedexNumber: 133,
@@ -511,9 +512,9 @@ export const EEVEE_HOLIDAY: Pokemon = {
     { amount: 3, ingredient: BEAN_SAUSAGE }
   ],
   skill: DreamShardMagnetS
-};
+});
 
-export const CHIKORITA: Pokemon = {
+export const CHIKORITA: Pokemon = basePokemon({
   name: 'CHIKORITA',
   displayName: 'Chikorita',
   pokedexNumber: 152,
@@ -537,7 +538,7 @@ export const CHIKORITA: Pokemon = {
     { amount: 3, ingredient: LARGE_LEEK }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const BAYLEEF: Pokemon = {
   ...evolvesFrom(CHIKORITA),
@@ -561,7 +562,7 @@ export const MEGANIUM: Pokemon = {
   carrySize: 20
 };
 
-export const CYNDAQUIL: Pokemon = {
+export const CYNDAQUIL: Pokemon = basePokemon({
   name: 'CYNDAQUIL',
   displayName: 'Cyndaquil',
   pokedexNumber: 155,
@@ -585,7 +586,7 @@ export const CYNDAQUIL: Pokemon = {
     { amount: 3, ingredient: PURE_OIL }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const QUILAVA: Pokemon = {
   ...evolvesFrom(CYNDAQUIL),
@@ -609,7 +610,7 @@ export const TYPHLOSION: Pokemon = {
   carrySize: 23
 };
 
-export const TOTODILE: Pokemon = {
+export const TOTODILE: Pokemon = basePokemon({
   name: 'TOTODILE',
   displayName: 'Totodile',
   pokedexNumber: 158,
@@ -632,7 +633,7 @@ export const TOTODILE: Pokemon = {
     { amount: 3, ingredient: PURE_OIL }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const CROCONAW: Pokemon = {
   ...evolvesFrom(TOTODILE),
@@ -690,7 +691,7 @@ export const STEELIX: Pokemon = {
   carrySize: 25
 };
 
-export const SNEASEL: Pokemon = {
+export const SNEASEL: Pokemon = basePokemon({
   name: 'SNEASEL',
   displayName: 'Sneasel',
   pokedexNumber: 215,
@@ -714,9 +715,9 @@ export const SNEASEL: Pokemon = {
     { amount: 4, ingredient: GREENGRASS_SOYBEANS }
   ],
   skill: TastyChanceS
-};
+});
 
-export const HOUNDOUR: Pokemon = {
+export const HOUNDOUR: Pokemon = basePokemon({
   name: 'HOUNDOUR',
   displayName: 'Houndour',
   pokedexNumber: 228,
@@ -740,7 +741,7 @@ export const HOUNDOUR: Pokemon = {
     { amount: 3, ingredient: LARGE_LEEK }
   ],
   skill: ChargeStrengthM
-};
+});
 
 export const HOUNDOOM: Pokemon = {
   ...evolvesFrom(HOUNDOUR),
@@ -753,7 +754,7 @@ export const HOUNDOOM: Pokemon = {
   carrySize: 16
 };
 
-export const SLAKOTH: Pokemon = {
+export const SLAKOTH: Pokemon = basePokemon({
   name: 'SLAKOTH',
   displayName: 'Slakoth',
   pokedexNumber: 287,
@@ -777,7 +778,7 @@ export const SLAKOTH: Pokemon = {
     { amount: 4, ingredient: FANCY_APPLE }
   ],
   skill: IngredientMagnetS
-};
+});
 
 export const VIGOROTH: Pokemon = {
   ...evolvesFrom(SLAKOTH),
@@ -801,7 +802,7 @@ export const SLAKING: Pokemon = {
   carrySize: 16
 };
 
-export const SWABLU: Pokemon = {
+export const SWABLU: Pokemon = basePokemon({
   name: 'SWABLU',
   displayName: 'Swablu',
   pokedexNumber: 333,
@@ -825,7 +826,7 @@ export const SWABLU: Pokemon = {
     { amount: 5, ingredient: FANCY_APPLE }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const ALTARIA: Pokemon = {
   ...evolvesFrom(SWABLU),
@@ -839,7 +840,7 @@ export const ALTARIA: Pokemon = {
   carrySize: 14
 };
 
-export const SHUPPET: Pokemon = {
+export const SHUPPET: Pokemon = basePokemon({
   name: 'SHUPPET',
   displayName: 'Shuppet',
   pokedexNumber: 353,
@@ -863,7 +864,7 @@ export const SHUPPET: Pokemon = {
     { amount: 3, ingredient: TASTY_MUSHROOM }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const BANETTE: Pokemon = {
   ...evolvesFrom(SHUPPET),
@@ -876,7 +877,7 @@ export const BANETTE: Pokemon = {
   carrySize: 19
 };
 
-export const SPHEAL: Pokemon = {
+export const SPHEAL: Pokemon = basePokemon({
   name: 'SPHEAL',
   displayName: 'Spheal',
   pokedexNumber: 363,
@@ -900,7 +901,7 @@ export const SPHEAL: Pokemon = {
     { amount: 4, ingredient: WARMING_GINGER }
   ],
   skill: IngredientMagnetS
-};
+});
 
 export const SEALEO: Pokemon = {
   ...evolvesFrom(SPHEAL),
@@ -935,7 +936,7 @@ export const WEAVILE: Pokemon = {
   carrySize: 21
 };
 
-export const MUNNA: Pokemon = {
+export const MUNNA: Pokemon = basePokemon({
   name: 'MUNNA',
   displayName: 'Munna',
   pokedexNumber: 517,
@@ -959,7 +960,7 @@ export const MUNNA: Pokemon = {
     { amount: 2, ingredient: ROUSING_COFFEE }
   ],
   skill: DreamShardMagnetSRange
-};
+});
 
 export const MUSHARNA: Pokemon = {
   ...evolvesFrom(MUNNA),

--- a/common/src/types/pokemon/ingredient-pokemon.ts
+++ b/common/src/types/pokemon/ingredient-pokemon.ts
@@ -59,7 +59,6 @@ import {
 import type { Pokemon } from './pokemon';
 
 export const BULBASAUR: Pokemon = basePokemon({
-  name: 'BULBASAUR',
   displayName: 'Bulbasaur',
   pokedexNumber: 1,
   specialty: 'ingredient',
@@ -107,7 +106,6 @@ export const VENUSAUR: Pokemon = {
 };
 
 export const CHARMANDER: Pokemon = basePokemon({
-  name: 'CHARMANDER',
   displayName: 'Charmander',
   pokedexNumber: 4,
   specialty: 'ingredient',
@@ -155,7 +153,6 @@ export const CHARIZARD: Pokemon = {
 };
 
 export const SQUIRTLE: Pokemon = basePokemon({
-  name: 'SQUIRTLE',
   displayName: 'Squirtle',
   pokedexNumber: 7,
   specialty: 'ingredient',
@@ -203,7 +200,6 @@ export const BLASTOISE: Pokemon = {
 };
 
 export const DIGLETT: Pokemon = basePokemon({
-  name: 'DIGLETT',
   displayName: 'Diglett',
   pokedexNumber: 50,
   specialty: 'ingredient',
@@ -240,7 +236,6 @@ export const DUGTRIO: Pokemon = {
 };
 
 export const BELLSPROUT: Pokemon = basePokemon({
-  name: 'BELLSPROUT',
   displayName: 'Bellsprout',
   pokedexNumber: 69,
   specialty: 'ingredient',
@@ -288,7 +283,6 @@ export const VICTREEBEL: Pokemon = {
 };
 
 export const GEODUDE: Pokemon = basePokemon({
-  name: 'GEODUDE',
   displayName: 'Geodude',
   pokedexNumber: 74,
   specialty: 'ingredient',
@@ -336,7 +330,6 @@ export const GOLEM: Pokemon = {
 };
 
 export const FARFETCHD: Pokemon = basePokemon({
-  name: 'FARFETCHD',
   displayName: "Farfetch'd",
   pokedexNumber: 83,
   specialty: 'ingredient',
@@ -362,7 +355,6 @@ export const FARFETCHD: Pokemon = basePokemon({
 });
 
 export const GASTLY: Pokemon = basePokemon({
-  name: 'GASTLY',
   displayName: 'Gastly',
   pokedexNumber: 92,
   specialty: 'ingredient',
@@ -410,7 +402,6 @@ export const GENGAR: Pokemon = {
 };
 
 export const KANGASKHAN: Pokemon = basePokemon({
-  name: 'KANGASKHAN',
   displayName: 'Kangaskhan',
   pokedexNumber: 115,
   specialty: 'ingredient',
@@ -436,7 +427,6 @@ export const KANGASKHAN: Pokemon = basePokemon({
 });
 
 export const CHANSEY: Pokemon = basePokemon({
-  name: 'CHANSEY',
   displayName: 'Chansey',
   pokedexNumber: 113,
   specialty: 'ingredient',
@@ -462,7 +452,6 @@ export const CHANSEY: Pokemon = basePokemon({
 });
 
 export const MR_MIME: Pokemon = basePokemon({
-  name: 'MR_MIME',
   displayName: 'Mr. Mime',
   pokedexNumber: 122,
   specialty: 'ingredient',
@@ -488,7 +477,6 @@ export const MR_MIME: Pokemon = basePokemon({
 });
 
 export const PINSIR: Pokemon = basePokemon({
-  name: 'PINSIR',
   displayName: 'Pinsir',
   pokedexNumber: 127,
   specialty: 'ingredient',
@@ -514,7 +502,6 @@ export const PINSIR: Pokemon = basePokemon({
 });
 
 export const DITTO: Pokemon = basePokemon({
-  name: 'DITTO',
   displayName: 'Ditto',
   pokedexNumber: 132,
   specialty: 'ingredient',
@@ -540,7 +527,6 @@ export const DITTO: Pokemon = basePokemon({
 });
 
 export const DRATINI: Pokemon = basePokemon({
-  name: 'DRATINI',
   displayName: 'Dratini',
   pokedexNumber: 147,
   specialty: 'ingredient',
@@ -588,7 +574,6 @@ export const DRAGONITE: Pokemon = {
 };
 
 export const WOOPER: Pokemon = basePokemon({
-  name: 'WOOPER',
   displayName: 'Wooper',
   pokedexNumber: 194,
   specialty: 'ingredient',
@@ -614,7 +599,6 @@ export const WOOPER: Pokemon = basePokemon({
 });
 
 export const WOOPER_PALDEAN: Pokemon = basePokemon({
-  name: 'WOOPER_PALDEAN',
   displayName: 'Wooper (Paldean Form)',
   pokedexNumber: 194,
   specialty: 'ingredient',
@@ -651,7 +635,6 @@ export const QUAGSIRE: Pokemon = {
 };
 
 export const DELIBIRD: Pokemon = basePokemon({
-  name: 'DELIBIRD',
   displayName: 'Delibird',
   pokedexNumber: 225,
   specialty: 'ingredient',
@@ -688,7 +671,6 @@ export const BLISSEY: Pokemon = {
 };
 
 export const LARVITAR: Pokemon = basePokemon({
-  name: 'LARVITAR',
   displayName: 'Larvitar',
   pokedexNumber: 246,
   specialty: 'ingredient',
@@ -737,7 +719,6 @@ export const TYRANITAR: Pokemon = {
 };
 
 export const MAWILE: Pokemon = basePokemon({
-  name: 'MAWILE',
   displayName: 'Mawile',
   pokedexNumber: 303,
   specialty: 'ingredient',
@@ -763,7 +744,6 @@ export const MAWILE: Pokemon = basePokemon({
 });
 
 export const ARON: Pokemon = basePokemon({
-  name: 'ARON',
   displayName: 'Aron',
   pokedexNumber: 304,
   specialty: 'ingredient',
@@ -811,7 +791,6 @@ export const AGGRON: Pokemon = {
 };
 
 export const ABSOL: Pokemon = basePokemon({
-  name: 'ABSOL',
   displayName: 'Absol',
   pokedexNumber: 359,
   specialty: 'ingredient',
@@ -837,7 +816,6 @@ export const ABSOL: Pokemon = basePokemon({
 });
 
 export const SHINX: Pokemon = basePokemon({
-  name: 'SHINX',
   displayName: 'Shinx',
   pokedexNumber: 403,
   specialty: 'ingredient',
@@ -907,7 +885,6 @@ export const HAPPINY: Pokemon = {
 };
 
 export const CROAGUNK: Pokemon = basePokemon({
-  name: 'CROAGUNK',
   displayName: 'Croagunk',
   pokedexNumber: 453,
   specialty: 'ingredient',
@@ -943,7 +920,6 @@ export const TOXICROAK: Pokemon = {
 };
 
 export const SNOVER: Pokemon = basePokemon({
-  name: 'SNOVER',
   displayName: 'Snover',
   pokedexNumber: 459,
   specialty: 'ingredient',
@@ -980,7 +956,6 @@ export const ABOMASNOW: Pokemon = {
 };
 
 export const GRUBBIN: Pokemon = basePokemon({
-  name: 'GRUBBIN',
   displayName: 'Grubbin',
   pokedexNumber: 736,
   specialty: 'ingredient',
@@ -1028,7 +1003,6 @@ export const VIKAVOLT: Pokemon = {
 };
 
 export const STUFFUL: Pokemon = basePokemon({
-  name: 'STUFFUL',
   displayName: 'Stufful',
   pokedexNumber: 759,
   specialty: 'ingredient',
@@ -1065,7 +1039,6 @@ export const BEWEAR: Pokemon = {
 };
 
 export const COMFEY: Pokemon = basePokemon({
-  name: 'COMFEY',
   displayName: 'Comfey',
   pokedexNumber: 764,
   specialty: 'ingredient',
@@ -1091,7 +1064,6 @@ export const COMFEY: Pokemon = basePokemon({
 });
 
 export const CRAMORANT: Pokemon = basePokemon({
-  name: 'CRAMORANT',
   displayName: 'Cramorant',
   pokedexNumber: 845,
   specialty: 'ingredient',
@@ -1117,7 +1089,6 @@ export const CRAMORANT: Pokemon = basePokemon({
 });
 
 export const SPRIGATITO: Pokemon = basePokemon({
-  name: 'SPRIGATITO',
   displayName: 'Sprigatito',
   pokedexNumber: 906,
   specialty: 'ingredient',
@@ -1166,7 +1137,6 @@ export const MEOWSCARADA: Pokemon = {
 };
 
 export const FUECOCO: Pokemon = basePokemon({
-  name: 'FUECOCO',
   displayName: 'Fuecoco',
   pokedexNumber: 909,
   specialty: 'ingredient',
@@ -1215,7 +1185,6 @@ export const SKELEDIRGE: Pokemon = {
 };
 
 export const QUAXLY: Pokemon = basePokemon({
-  name: 'QUAXLY',
   displayName: 'Quaxly',
   pokedexNumber: 912,
   specialty: 'ingredient',

--- a/common/src/types/pokemon/ingredient-pokemon.ts
+++ b/common/src/types/pokemon/ingredient-pokemon.ts
@@ -1,3 +1,4 @@
+import { basePokemon } from '../../utils';
 import { evolvesFrom, evolvesInto } from '../../utils/pokemon-utils/evolution-utils';
 import { toSeconds } from '../../utils/time-utils/frequency-utils';
 import {
@@ -57,7 +58,7 @@ import {
 
 import type { Pokemon } from './pokemon';
 
-export const BULBASAUR: Pokemon = {
+export const BULBASAUR: Pokemon = basePokemon({
   name: 'BULBASAUR',
   displayName: 'Bulbasaur',
   pokedexNumber: 1,
@@ -81,7 +82,7 @@ export const BULBASAUR: Pokemon = {
     { amount: 6, ingredient: SOFT_POTATO }
   ],
   skill: IngredientMagnetS
-};
+});
 
 export const IVYSAUR: Pokemon = {
   ...evolvesFrom(BULBASAUR),
@@ -105,7 +106,7 @@ export const VENUSAUR: Pokemon = {
   carrySize: 17
 };
 
-export const CHARMANDER: Pokemon = {
+export const CHARMANDER: Pokemon = basePokemon({
   name: 'CHARMANDER',
   displayName: 'Charmander',
   pokedexNumber: 4,
@@ -129,7 +130,7 @@ export const CHARMANDER: Pokemon = {
     { amount: 6, ingredient: FIERY_HERB }
   ],
   skill: IngredientMagnetS
-};
+});
 
 export const CHARMELEON: Pokemon = {
   ...evolvesFrom(CHARMANDER),
@@ -153,7 +154,7 @@ export const CHARIZARD: Pokemon = {
   carrySize: 19
 };
 
-export const SQUIRTLE: Pokemon = {
+export const SQUIRTLE: Pokemon = basePokemon({
   name: 'SQUIRTLE',
   displayName: 'Squirtle',
   pokedexNumber: 7,
@@ -177,7 +178,7 @@ export const SQUIRTLE: Pokemon = {
     { amount: 7, ingredient: BEAN_SAUSAGE }
   ],
   skill: IngredientMagnetS
-};
+});
 
 export const WARTORTLE: Pokemon = {
   ...evolvesFrom(SQUIRTLE),
@@ -201,7 +202,7 @@ export const BLASTOISE: Pokemon = {
   carrySize: 17
 };
 
-export const DIGLETT: Pokemon = {
+export const DIGLETT: Pokemon = basePokemon({
   name: 'DIGLETT',
   displayName: 'Diglett',
   pokedexNumber: 50,
@@ -225,7 +226,7 @@ export const DIGLETT: Pokemon = {
     { amount: 8, ingredient: GREENGRASS_SOYBEANS }
   ],
   skill: ChargeStrengthS
-};
+});
 
 export const DUGTRIO: Pokemon = {
   ...evolvesFrom(DIGLETT),
@@ -238,7 +239,7 @@ export const DUGTRIO: Pokemon = {
   carrySize: 16
 };
 
-export const BELLSPROUT: Pokemon = {
+export const BELLSPROUT: Pokemon = basePokemon({
   name: 'BELLSPROUT',
   displayName: 'Bellsprout',
   pokedexNumber: 69,
@@ -262,7 +263,7 @@ export const BELLSPROUT: Pokemon = {
     { amount: 4, ingredient: LARGE_LEEK }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const WEEPINBELL: Pokemon = {
   ...evolvesFrom(BELLSPROUT),
@@ -286,7 +287,7 @@ export const VICTREEBEL: Pokemon = {
   carrySize: 17
 };
 
-export const GEODUDE: Pokemon = {
+export const GEODUDE: Pokemon = basePokemon({
   name: 'GEODUDE',
   displayName: 'Geodude',
   pokedexNumber: 74,
@@ -310,7 +311,7 @@ export const GEODUDE: Pokemon = {
     { amount: 4, ingredient: TASTY_MUSHROOM }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const GRAVELER: Pokemon = {
   ...evolvesFrom(GEODUDE),
@@ -334,7 +335,7 @@ export const GOLEM: Pokemon = {
   carrySize: 16
 };
 
-export const FARFETCHD: Pokemon = {
+export const FARFETCHD: Pokemon = basePokemon({
   name: 'FARFETCHD',
   displayName: "Farfetch'd",
   pokedexNumber: 83,
@@ -358,9 +359,9 @@ export const FARFETCHD: Pokemon = {
     { amount: 12, ingredient: WARMING_GINGER }
   ],
   skill: ChargeStrengthS
-};
+});
 
-export const GASTLY: Pokemon = {
+export const GASTLY: Pokemon = basePokemon({
   name: 'GASTLY',
   displayName: 'Gastly',
   pokedexNumber: 92,
@@ -384,7 +385,7 @@ export const GASTLY: Pokemon = {
     { amount: 8, ingredient: PURE_OIL }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const HAUNTER: Pokemon = {
   ...evolvesFrom(GASTLY),
@@ -408,7 +409,7 @@ export const GENGAR: Pokemon = {
   carrySize: 18
 };
 
-export const KANGASKHAN: Pokemon = {
+export const KANGASKHAN: Pokemon = basePokemon({
   name: 'KANGASKHAN',
   displayName: 'Kangaskhan',
   pokedexNumber: 115,
@@ -432,9 +433,9 @@ export const KANGASKHAN: Pokemon = {
     { amount: 8, ingredient: GREENGRASS_SOYBEANS }
   ],
   skill: IngredientMagnetS
-};
+});
 
-export const CHANSEY: Pokemon = {
+export const CHANSEY: Pokemon = basePokemon({
   name: 'CHANSEY',
   displayName: 'Chansey',
   pokedexNumber: 113,
@@ -458,9 +459,9 @@ export const CHANSEY: Pokemon = {
     { amount: 8, ingredient: HONEY }
   ],
   skill: EnergyForEveryone
-};
+});
 
-export const MR_MIME: Pokemon = {
+export const MR_MIME: Pokemon = basePokemon({
   name: 'MR_MIME',
   displayName: 'Mr. Mime',
   pokedexNumber: 122,
@@ -484,9 +485,9 @@ export const MR_MIME: Pokemon = {
     { amount: 4, ingredient: LARGE_LEEK }
   ],
   skill: SkillCopyMimic
-};
+});
 
-export const PINSIR: Pokemon = {
+export const PINSIR: Pokemon = basePokemon({
   name: 'PINSIR',
   displayName: 'Pinsir',
   pokedexNumber: 127,
@@ -510,9 +511,9 @@ export const PINSIR: Pokemon = {
     { amount: 7, ingredient: BEAN_SAUSAGE }
   ],
   skill: ChargeStrengthS
-};
+});
 
-export const DITTO: Pokemon = {
+export const DITTO: Pokemon = basePokemon({
   name: 'DITTO',
   displayName: 'Ditto',
   pokedexNumber: 132,
@@ -536,9 +537,9 @@ export const DITTO: Pokemon = {
     { amount: 3, ingredient: SLOWPOKE_TAIL }
   ],
   skill: SkillCopyTransform
-};
+});
 
-export const DRATINI: Pokemon = {
+export const DRATINI: Pokemon = basePokemon({
   name: 'DRATINI',
   displayName: 'Dratini',
   pokedexNumber: 147,
@@ -562,7 +563,7 @@ export const DRATINI: Pokemon = {
     { amount: 8, ingredient: PURE_OIL }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const DRAGONAIR: Pokemon = {
   ...evolvesFrom(DRATINI),
@@ -586,7 +587,7 @@ export const DRAGONITE: Pokemon = {
   carrySize: 20
 };
 
-export const WOOPER: Pokemon = {
+export const WOOPER: Pokemon = basePokemon({
   name: 'WOOPER',
   displayName: 'Wooper',
   pokedexNumber: 194,
@@ -610,9 +611,9 @@ export const WOOPER: Pokemon = {
     { amount: 12, ingredient: BEAN_SAUSAGE }
   ],
   skill: ChargeEnergyS
-};
+});
 
-export const WOOPER_PALDEAN: Pokemon = {
+export const WOOPER_PALDEAN: Pokemon = basePokemon({
   name: 'WOOPER_PALDEAN',
   displayName: 'Wooper (Paldean Form)',
   pokedexNumber: 194,
@@ -636,7 +637,7 @@ export const WOOPER_PALDEAN: Pokemon = {
     { amount: 9, ingredient: SOFT_POTATO }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const QUAGSIRE: Pokemon = {
   ...evolvesFrom(WOOPER),
@@ -649,7 +650,7 @@ export const QUAGSIRE: Pokemon = {
   carrySize: 16
 };
 
-export const DELIBIRD: Pokemon = {
+export const DELIBIRD: Pokemon = basePokemon({
   name: 'DELIBIRD',
   displayName: 'Delibird',
   pokedexNumber: 225,
@@ -673,7 +674,7 @@ export const DELIBIRD: Pokemon = {
     { amount: 5, ingredient: SOOTHING_CACAO }
   ],
   skill: IngredientMagnetS
-};
+});
 
 export const BLISSEY: Pokemon = {
   ...evolvesFrom(CHANSEY),
@@ -686,7 +687,7 @@ export const BLISSEY: Pokemon = {
   carrySize: 21
 };
 
-export const LARVITAR: Pokemon = {
+export const LARVITAR: Pokemon = basePokemon({
   name: 'LARVITAR',
   displayName: 'Larvitar',
   pokedexNumber: 246,
@@ -710,7 +711,7 @@ export const LARVITAR: Pokemon = {
     { amount: 8, ingredient: BEAN_SAUSAGE }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const PUPITAR: Pokemon = {
   ...evolvesFrom(LARVITAR),
@@ -735,7 +736,7 @@ export const TYRANITAR: Pokemon = {
   carrySize: 19
 };
 
-export const MAWILE: Pokemon = {
+export const MAWILE: Pokemon = basePokemon({
   name: 'MAWILE',
   displayName: 'Mawile',
   pokedexNumber: 303,
@@ -759,9 +760,9 @@ export const MAWILE: Pokemon = {
     { amount: 8, ingredient: SNOOZY_TOMATO }
   ],
   skill: IngredientDrawSHyperCutter
-};
+});
 
-export const ARON: Pokemon = {
+export const ARON: Pokemon = basePokemon({
   name: 'ARON',
   displayName: 'Aron',
   pokedexNumber: 304,
@@ -785,7 +786,7 @@ export const ARON: Pokemon = {
     { amount: 7, ingredient: GREENGRASS_SOYBEANS }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const LAIRON: Pokemon = {
   ...evolvesFrom(ARON),
@@ -809,7 +810,7 @@ export const AGGRON: Pokemon = {
   carrySize: 18
 };
 
-export const ABSOL: Pokemon = {
+export const ABSOL: Pokemon = basePokemon({
   name: 'ABSOL',
   displayName: 'Absol',
   pokedexNumber: 359,
@@ -833,9 +834,9 @@ export const ABSOL: Pokemon = {
     { amount: 7, ingredient: TASTY_MUSHROOM }
   ],
   skill: ChargeStrengthS
-};
+});
 
-export const SHINX: Pokemon = {
+export const SHINX: Pokemon = basePokemon({
   name: 'SHINX',
   displayName: 'Shinx',
   pokedexNumber: 403,
@@ -859,7 +860,7 @@ export const SHINX: Pokemon = {
     { amount: 5, ingredient: ROUSING_COFFEE }
   ],
   skill: CookingPowerUpS
-};
+});
 
 export const LUXIO: Pokemon = {
   ...evolvesFrom(SHINX),
@@ -905,7 +906,7 @@ export const HAPPINY: Pokemon = {
   carrySize: 7
 };
 
-export const CROAGUNK: Pokemon = {
+export const CROAGUNK: Pokemon = basePokemon({
   name: 'CROAGUNK',
   displayName: 'Croagunk',
   pokedexNumber: 453,
@@ -928,7 +929,7 @@ export const CROAGUNK: Pokemon = {
     { amount: 8, ingredient: BEAN_SAUSAGE }
   ],
   skill: ChargeStrengthS
-};
+});
 
 export const TOXICROAK: Pokemon = {
   ...evolvesFrom(CROAGUNK),
@@ -941,7 +942,7 @@ export const TOXICROAK: Pokemon = {
   carrySize: 14
 };
 
-export const SNOVER: Pokemon = {
+export const SNOVER: Pokemon = basePokemon({
   name: 'SNOVER',
   displayName: 'Snover',
   pokedexNumber: 459,
@@ -965,7 +966,7 @@ export const SNOVER: Pokemon = {
     { amount: 5, ingredient: TASTY_MUSHROOM }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const ABOMASNOW: Pokemon = {
   ...evolvesFrom(SNOVER),
@@ -978,7 +979,7 @@ export const ABOMASNOW: Pokemon = {
   carrySize: 21
 };
 
-export const GRUBBIN: Pokemon = {
+export const GRUBBIN: Pokemon = basePokemon({
   name: 'GRUBBIN',
   displayName: 'Grubbin',
   pokedexNumber: 736,
@@ -1002,7 +1003,7 @@ export const GRUBBIN: Pokemon = {
     { amount: 11, ingredient: HONEY }
   ],
   skill: ChargeStrengthS
-};
+});
 
 export const CHARJABUG: Pokemon = {
   ...evolvesFrom(GRUBBIN),
@@ -1026,7 +1027,7 @@ export const VIKAVOLT: Pokemon = {
   carrySize: 19
 };
 
-export const STUFFUL: Pokemon = {
+export const STUFFUL: Pokemon = basePokemon({
   name: 'STUFFUL',
   displayName: 'Stufful',
   pokedexNumber: 759,
@@ -1050,7 +1051,7 @@ export const STUFFUL: Pokemon = {
     { amount: 9, ingredient: FANCY_EGG }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const BEWEAR: Pokemon = {
   ...evolvesFrom(STUFFUL),
@@ -1063,7 +1064,7 @@ export const BEWEAR: Pokemon = {
   carrySize: 20
 };
 
-export const COMFEY: Pokemon = {
+export const COMFEY: Pokemon = basePokemon({
   name: 'COMFEY',
   displayName: 'Comfey',
   pokedexNumber: 764,
@@ -1087,9 +1088,9 @@ export const COMFEY: Pokemon = {
     { amount: 7, ingredient: SOOTHING_CACAO }
   ],
   skill: EnergizingCheerS
-};
+});
 
-export const CRAMORANT: Pokemon = {
+export const CRAMORANT: Pokemon = basePokemon({
   name: 'CRAMORANT',
   displayName: 'Cramorant',
   pokedexNumber: 845,
@@ -1113,9 +1114,9 @@ export const CRAMORANT: Pokemon = {
     { amount: 8, ingredient: FANCY_EGG }
   ],
   skill: TastyChanceS
-};
+});
 
-export const SPRIGATITO: Pokemon = {
+export const SPRIGATITO: Pokemon = basePokemon({
   name: 'SPRIGATITO',
   displayName: 'Sprigatito',
   pokedexNumber: 906,
@@ -1139,7 +1140,7 @@ export const SPRIGATITO: Pokemon = {
     { amount: 8, ingredient: WARMING_GINGER }
   ],
   skill: CookingPowerUpS
-};
+});
 
 export const FLORAGATO: Pokemon = {
   ...evolvesFrom(SPRIGATITO),
@@ -1164,7 +1165,7 @@ export const MEOWSCARADA: Pokemon = {
   carrySize: 18
 };
 
-export const FUECOCO: Pokemon = {
+export const FUECOCO: Pokemon = basePokemon({
   name: 'FUECOCO',
   displayName: 'Fuecoco',
   pokedexNumber: 909,
@@ -1188,7 +1189,7 @@ export const FUECOCO: Pokemon = {
     { amount: 5, ingredient: FIERY_HERB }
   ],
   skill: ChargeEnergyS
-};
+});
 
 export const CROCALOR: Pokemon = {
   ...evolvesFrom(FUECOCO),
@@ -1213,7 +1214,7 @@ export const SKELEDIRGE: Pokemon = {
   carrySize: 19
 };
 
-export const QUAXLY: Pokemon = {
+export const QUAXLY: Pokemon = basePokemon({
   name: 'QUAXLY',
   displayName: 'Quaxly',
   pokedexNumber: 912,
@@ -1237,7 +1238,7 @@ export const QUAXLY: Pokemon = {
     { amount: 6, ingredient: PURE_OIL }
   ],
   skill: ChargeStrengthM
-};
+});
 
 export const QUAXWELL: Pokemon = {
   ...evolvesFrom(QUAXLY),

--- a/common/src/types/pokemon/skill-pokemon.ts
+++ b/common/src/types/pokemon/skill-pokemon.ts
@@ -1,3 +1,4 @@
+import { basePokemon } from '../../utils';
 import { evolvesFrom, evolvesInto } from '../../utils/pokemon-utils/evolution-utils';
 import { toSeconds } from '../../utils/time-utils/frequency-utils';
 import {
@@ -69,7 +70,7 @@ import { IngredientDrawSSuperLuck } from '../mainskill/mainskills/ingredient-dra
 
 import type { Pokemon } from './pokemon';
 
-export const PIKACHU_HOLIDAY: Pokemon = {
+export const PIKACHU_HOLIDAY: Pokemon = basePokemon({
   name: 'PIKACHU_HOLIDAY',
   displayName: 'Pikachu (Holiday)',
   pokedexNumber: 25,
@@ -93,9 +94,9 @@ export const PIKACHU_HOLIDAY: Pokemon = {
     { amount: 3, ingredient: WARMING_GINGER }
   ],
   skill: DreamShardMagnetS
-};
+});
 
-export const JIGGLYPUFF: Pokemon = {
+export const JIGGLYPUFF: Pokemon = basePokemon({
   name: 'JIGGLYPUFF',
   displayName: 'Jigglypuff',
   pokedexNumber: 39,
@@ -119,7 +120,7 @@ export const JIGGLYPUFF: Pokemon = {
     { amount: 2, ingredient: SOOTHING_CACAO }
   ],
   skill: EnergyForEveryone
-};
+});
 
 export const WIGGLYTUFF: Pokemon = {
   ...evolvesFrom(JIGGLYPUFF),
@@ -132,7 +133,7 @@ export const WIGGLYTUFF: Pokemon = {
   carrySize: 13
 };
 
-export const MEOWTH: Pokemon = {
+export const MEOWTH: Pokemon = basePokemon({
   name: 'MEOWTH',
   displayName: 'Meowth',
   pokedexNumber: 52,
@@ -155,7 +156,7 @@ export const MEOWTH: Pokemon = {
     { amount: 3, ingredient: BEAN_SAUSAGE }
   ],
   skill: DreamShardMagnetS
-};
+});
 
 export const PERSIAN: Pokemon = {
   ...evolvesFrom(MEOWTH),
@@ -168,7 +169,7 @@ export const PERSIAN: Pokemon = {
   carrySize: 12
 };
 
-export const PSYDUCK: Pokemon = {
+export const PSYDUCK: Pokemon = basePokemon({
   name: 'PSYDUCK',
   displayName: 'Psyduck',
   pokedexNumber: 54,
@@ -192,7 +193,7 @@ export const PSYDUCK: Pokemon = {
     { amount: 5, ingredient: BEAN_SAUSAGE }
   ],
   skill: ChargeStrengthSRange
-};
+});
 
 export const GOLDUCK: Pokemon = {
   ...evolvesFrom(PSYDUCK),
@@ -205,7 +206,7 @@ export const GOLDUCK: Pokemon = {
   carrySize: 14
 };
 
-export const GROWLITHE: Pokemon = {
+export const GROWLITHE: Pokemon = basePokemon({
   name: 'GROWLITHE',
   displayName: 'Growlithe',
   pokedexNumber: 58,
@@ -229,7 +230,7 @@ export const GROWLITHE: Pokemon = {
     { amount: 5, ingredient: MOOMOO_MILK }
   ],
   skill: ExtraHelpfulS
-};
+});
 
 export const ARCANINE: Pokemon = {
   ...evolvesFrom(GROWLITHE),
@@ -242,7 +243,7 @@ export const ARCANINE: Pokemon = {
   carrySize: 16
 };
 
-export const SLOWPOKE: Pokemon = {
+export const SLOWPOKE: Pokemon = basePokemon({
   name: 'SLOWPOKE',
   displayName: 'Slowpoke',
   pokedexNumber: 79,
@@ -266,7 +267,7 @@ export const SLOWPOKE: Pokemon = {
     { amount: 5, ingredient: SNOOZY_TOMATO }
   ],
   skill: EnergizingCheerS
-};
+});
 
 export const SLOWBRO: Pokemon = {
   ...evolvesFrom(SLOWPOKE),
@@ -279,7 +280,7 @@ export const SLOWBRO: Pokemon = {
   carrySize: 16
 };
 
-export const MAGNEMITE: Pokemon = {
+export const MAGNEMITE: Pokemon = basePokemon({
   name: 'MAGNEMITE',
   displayName: 'Magnemite',
   pokedexNumber: 81,
@@ -302,7 +303,7 @@ export const MAGNEMITE: Pokemon = {
     { amount: 3, ingredient: FIERY_HERB }
   ],
   skill: CookingPowerUpS
-};
+});
 
 export const MAGNETON: Pokemon = {
   ...evolvesFrom(MAGNEMITE),
@@ -315,7 +316,7 @@ export const MAGNETON: Pokemon = {
   carrySize: 11
 };
 
-export const EEVEE: Pokemon = {
+export const EEVEE: Pokemon = basePokemon({
   name: 'EEVEE',
   displayName: 'Eevee',
   pokedexNumber: 133,
@@ -339,7 +340,7 @@ export const EEVEE: Pokemon = {
     { amount: 3, ingredient: BEAN_SAUSAGE }
   ],
   skill: IngredientMagnetS
-};
+});
 
 export const VAPOREON: Pokemon = {
   ...evolvesFrom(EEVEE),
@@ -391,7 +392,7 @@ export const IGGLYBUFF: Pokemon = {
   carrySize: 8
 };
 
-export const TOGEPI: Pokemon = {
+export const TOGEPI: Pokemon = basePokemon({
   name: 'TOGEPI',
   displayName: 'Togepi',
   pokedexNumber: 175,
@@ -415,7 +416,7 @@ export const TOGEPI: Pokemon = {
     { amount: 3, ingredient: SOOTHING_CACAO }
   ],
   skill: Metronome
-};
+});
 
 export const TOGETIC: Pokemon = {
   ...evolvesFrom(TOGEPI),
@@ -428,7 +429,7 @@ export const TOGETIC: Pokemon = {
   carrySize: 10
 };
 
-export const MAREEP: Pokemon = {
+export const MAREEP: Pokemon = basePokemon({
   name: 'MAREEP',
   displayName: 'Mareep',
   pokedexNumber: 179,
@@ -451,7 +452,7 @@ export const MAREEP: Pokemon = {
     { amount: 4, ingredient: FANCY_EGG }
   ],
   skill: ChargeStrengthM
-};
+});
 
 export const FLAAFFY: Pokemon = {
   ...evolvesFrom(MAREEP),
@@ -475,7 +476,7 @@ export const AMPHAROS: Pokemon = {
   carrySize: 15
 };
 
-export const SUDOWOODO: Pokemon = {
+export const SUDOWOODO: Pokemon = basePokemon({
   name: 'SUDOWOODO',
   displayName: 'Sudowoodo',
   pokedexNumber: 185,
@@ -499,7 +500,7 @@ export const SUDOWOODO: Pokemon = {
     { amount: 2, ingredient: TASTY_MUSHROOM }
   ],
   skill: ChargeStrengthM
-};
+});
 
 export const ESPEON: Pokemon = {
   ...evolvesFrom(EEVEE),
@@ -527,7 +528,7 @@ export const UMBREON: Pokemon = {
   skill: ChargeEnergySMoonlight
 };
 
-export const MURKROW: Pokemon = {
+export const MURKROW: Pokemon = basePokemon({
   name: 'MURKROW',
   displayName: 'Murkrow',
   pokedexNumber: 198,
@@ -551,7 +552,7 @@ export const MURKROW: Pokemon = {
     { amount: 4, ingredient: FIERY_HERB }
   ],
   skill: IngredientDrawSSuperLuck
-};
+});
 
 export const SLOWKING: Pokemon = {
   ...evolvesFrom(SLOWPOKE),
@@ -564,7 +565,7 @@ export const SLOWKING: Pokemon = {
   carrySize: 17
 };
 
-export const WOBBUFFET: Pokemon = {
+export const WOBBUFFET: Pokemon = basePokemon({
   name: 'WOBBUFFET',
   displayName: 'Wobbuffet',
   pokedexNumber: 202,
@@ -588,9 +589,9 @@ export const WOBBUFFET: Pokemon = {
     { amount: 3, ingredient: PURE_OIL }
   ],
   skill: EnergizingCheerS
-};
+});
 
-export const HERACROSS: Pokemon = {
+export const HERACROSS: Pokemon = basePokemon({
   name: 'HERACROSS',
   displayName: 'Heracross',
   pokedexNumber: 214,
@@ -614,9 +615,9 @@ export const HERACROSS: Pokemon = {
     { amount: 4, ingredient: BEAN_SAUSAGE }
   ],
   skill: IngredientMagnetS
-};
+});
 
-export const RAIKOU: Pokemon = {
+export const RAIKOU: Pokemon = basePokemon({
   name: 'RAIKOU',
   displayName: 'Raikou',
   pokedexNumber: 243,
@@ -640,9 +641,9 @@ export const RAIKOU: Pokemon = {
     { amount: 2, ingredient: LARGE_LEEK }
   ],
   skill: HelperBoost
-};
+});
 
-export const ENTEI: Pokemon = {
+export const ENTEI: Pokemon = basePokemon({
   name: 'ENTEI',
   displayName: 'Entei',
   pokedexNumber: 244,
@@ -666,9 +667,9 @@ export const ENTEI: Pokemon = {
     { amount: 3, ingredient: TASTY_MUSHROOM }
   ],
   skill: HelperBoost
-};
+});
 
-export const SUICUNE: Pokemon = {
+export const SUICUNE: Pokemon = basePokemon({
   name: 'SUICUNE',
   displayName: 'Suicune',
   pokedexNumber: 245,
@@ -692,9 +693,9 @@ export const SUICUNE: Pokemon = {
     { amount: 2, ingredient: GREENGRASS_CORN }
   ],
   skill: HelperBoost
-};
+});
 
-export const RALTS: Pokemon = {
+export const RALTS: Pokemon = basePokemon({
   name: 'RALTS',
   displayName: 'Ralts',
   pokedexNumber: 280,
@@ -718,7 +719,7 @@ export const RALTS: Pokemon = {
     { amount: 2, ingredient: LARGE_LEEK }
   ],
   skill: EnergyForEveryone
-};
+});
 
 export const KIRLIA: Pokemon = {
   ...evolvesFrom(RALTS),
@@ -742,7 +743,7 @@ export const GARDEVOIR: Pokemon = {
   carrySize: 18
 };
 
-export const SABLEYE: Pokemon = {
+export const SABLEYE: Pokemon = basePokemon({
   name: 'SABLEYE',
   displayName: 'Sableye',
   pokedexNumber: 302,
@@ -766,9 +767,9 @@ export const SABLEYE: Pokemon = {
     { amount: 3, ingredient: SOOTHING_CACAO }
   ],
   skill: DreamShardMagnetSRange
-};
+});
 
-export const GULPIN: Pokemon = {
+export const GULPIN: Pokemon = basePokemon({
   name: 'GULPIN',
   displayName: 'Gulpin',
   pokedexNumber: 316,
@@ -792,7 +793,7 @@ export const GULPIN: Pokemon = {
     { amount: 4, ingredient: HONEY }
   ],
   skill: DreamShardMagnetSRange
-};
+});
 
 export const SWALOT: Pokemon = {
   ...evolvesFrom(GULPIN),
@@ -827,7 +828,7 @@ export const BONSLY: Pokemon = {
   carrySize: 8
 };
 
-export const DRIFLOON: Pokemon = {
+export const DRIFLOON: Pokemon = basePokemon({
   name: 'DRIFLOON',
   displayName: 'Drifloon',
   pokedexNumber: 425,
@@ -851,7 +852,8 @@ export const DRIFLOON: Pokemon = {
     { amount: 4, ingredient: SOFT_POTATO }
   ],
   skill: ChargeStrengthSStockpile
-};
+});
+
 export const DRIFBLIM: Pokemon = {
   ...evolvesFrom(DRIFLOON),
   name: 'DRIFBLIM',
@@ -874,7 +876,7 @@ export const HONCHKROW: Pokemon = {
   carrySize: 18
 };
 
-export const RIOLU: Pokemon = {
+export const RIOLU: Pokemon = basePokemon({
   name: 'RIOLU',
   displayName: 'Riolu',
   pokedexNumber: 447,
@@ -898,7 +900,7 @@ export const RIOLU: Pokemon = {
     { amount: 4, ingredient: FANCY_EGG }
   ],
   skill: DreamShardMagnetS
-};
+});
 
 export const LUCARIO: Pokemon = {
   ...evolvesFrom(RIOLU),
@@ -973,7 +975,7 @@ export const GALLADE: Pokemon = {
   skill: ExtraHelpfulS
 };
 
-export const CRESSELIA: Pokemon = {
+export const CRESSELIA: Pokemon = basePokemon({
   name: 'CRESSELIA',
   displayName: 'Cresselia',
   pokedexNumber: 488,
@@ -997,9 +999,9 @@ export const CRESSELIA: Pokemon = {
     { amount: 4, ingredient: SNOOZY_TOMATO }
   ],
   skill: EnergyForEveryoneLunarBlessing
-};
+});
 
-export const RUFFLET: Pokemon = {
+export const RUFFLET: Pokemon = basePokemon({
   name: 'RUFFLET',
   displayName: 'Rufflet',
   pokedexNumber: 627,
@@ -1023,7 +1025,7 @@ export const RUFFLET: Pokemon = {
     { amount: 2, ingredient: ROUSING_COFFEE }
   ],
   skill: BerryBurst
-};
+});
 
 export const BRAVIARY: Pokemon = {
   ...evolvesFrom(RUFFLET),
@@ -1049,7 +1051,7 @@ export const SYLVEON: Pokemon = {
   skill: EnergyForEveryone
 };
 
-export const DEDENNE: Pokemon = {
+export const DEDENNE: Pokemon = basePokemon({
   name: 'DEDENNE',
   displayName: 'Dedenne',
   pokedexNumber: 702,
@@ -1073,9 +1075,9 @@ export const DEDENNE: Pokemon = {
     { amount: 2, ingredient: GREENGRASS_CORN }
   ],
   skill: TastyChanceS
-};
+});
 
-export const MIMIKYU: Pokemon = {
+export const MIMIKYU: Pokemon = basePokemon({
   name: 'MIMIKYU',
   displayName: 'Mimikyu',
   pokedexNumber: 778,
@@ -1099,9 +1101,9 @@ export const MIMIKYU: Pokemon = {
     { amount: 2, ingredient: TASTY_MUSHROOM }
   ],
   skill: BerryBurstDisguise
-};
+});
 
-export const PAWMI: Pokemon = {
+export const PAWMI: Pokemon = basePokemon({
   name: 'PAWMI',
   displayName: 'Pawmi',
   pokedexNumber: 921,
@@ -1125,7 +1127,7 @@ export const PAWMI: Pokemon = {
     { amount: 5, ingredient: FANCY_EGG }
   ],
   skill: EnergyForEveryone
-};
+});
 
 export const PAWMO: Pokemon = {
   ...evolvesFrom(PAWMI),

--- a/common/src/types/pokemon/skill-pokemon.ts
+++ b/common/src/types/pokemon/skill-pokemon.ts
@@ -71,7 +71,6 @@ import { IngredientDrawSSuperLuck } from '../mainskill/mainskills/ingredient-dra
 import type { Pokemon } from './pokemon';
 
 export const PIKACHU_HOLIDAY: Pokemon = basePokemon({
-  name: 'PIKACHU_HOLIDAY',
   displayName: 'Pikachu (Holiday)',
   pokedexNumber: 25,
   specialty: 'skill',
@@ -97,7 +96,6 @@ export const PIKACHU_HOLIDAY: Pokemon = basePokemon({
 });
 
 export const JIGGLYPUFF: Pokemon = basePokemon({
-  name: 'JIGGLYPUFF',
   displayName: 'Jigglypuff',
   pokedexNumber: 39,
   specialty: 'skill',
@@ -134,7 +132,6 @@ export const WIGGLYTUFF: Pokemon = {
 };
 
 export const MEOWTH: Pokemon = basePokemon({
-  name: 'MEOWTH',
   displayName: 'Meowth',
   pokedexNumber: 52,
   specialty: 'skill',
@@ -170,7 +167,6 @@ export const PERSIAN: Pokemon = {
 };
 
 export const PSYDUCK: Pokemon = basePokemon({
-  name: 'PSYDUCK',
   displayName: 'Psyduck',
   pokedexNumber: 54,
   specialty: 'skill',
@@ -207,7 +203,6 @@ export const GOLDUCK: Pokemon = {
 };
 
 export const GROWLITHE: Pokemon = basePokemon({
-  name: 'GROWLITHE',
   displayName: 'Growlithe',
   pokedexNumber: 58,
   specialty: 'skill',
@@ -244,7 +239,6 @@ export const ARCANINE: Pokemon = {
 };
 
 export const SLOWPOKE: Pokemon = basePokemon({
-  name: 'SLOWPOKE',
   displayName: 'Slowpoke',
   pokedexNumber: 79,
   specialty: 'skill',
@@ -281,7 +275,6 @@ export const SLOWBRO: Pokemon = {
 };
 
 export const MAGNEMITE: Pokemon = basePokemon({
-  name: 'MAGNEMITE',
   displayName: 'Magnemite',
   pokedexNumber: 81,
   specialty: 'skill',
@@ -317,7 +310,6 @@ export const MAGNETON: Pokemon = {
 };
 
 export const EEVEE: Pokemon = basePokemon({
-  name: 'EEVEE',
   displayName: 'Eevee',
   pokedexNumber: 133,
   specialty: 'skill',
@@ -393,7 +385,6 @@ export const IGGLYBUFF: Pokemon = {
 };
 
 export const TOGEPI: Pokemon = basePokemon({
-  name: 'TOGEPI',
   displayName: 'Togepi',
   pokedexNumber: 175,
   specialty: 'skill',
@@ -430,7 +421,6 @@ export const TOGETIC: Pokemon = {
 };
 
 export const MAREEP: Pokemon = basePokemon({
-  name: 'MAREEP',
   displayName: 'Mareep',
   pokedexNumber: 179,
   specialty: 'skill',
@@ -477,7 +467,6 @@ export const AMPHAROS: Pokemon = {
 };
 
 export const SUDOWOODO: Pokemon = basePokemon({
-  name: 'SUDOWOODO',
   displayName: 'Sudowoodo',
   pokedexNumber: 185,
   specialty: 'skill',
@@ -529,7 +518,6 @@ export const UMBREON: Pokemon = {
 };
 
 export const MURKROW: Pokemon = basePokemon({
-  name: 'MURKROW',
   displayName: 'Murkrow',
   pokedexNumber: 198,
   specialty: 'skill',
@@ -566,7 +554,6 @@ export const SLOWKING: Pokemon = {
 };
 
 export const WOBBUFFET: Pokemon = basePokemon({
-  name: 'WOBBUFFET',
   displayName: 'Wobbuffet',
   pokedexNumber: 202,
   specialty: 'skill',
@@ -592,7 +579,6 @@ export const WOBBUFFET: Pokemon = basePokemon({
 });
 
 export const HERACROSS: Pokemon = basePokemon({
-  name: 'HERACROSS',
   displayName: 'Heracross',
   pokedexNumber: 214,
   specialty: 'skill',
@@ -618,7 +604,6 @@ export const HERACROSS: Pokemon = basePokemon({
 });
 
 export const RAIKOU: Pokemon = basePokemon({
-  name: 'RAIKOU',
   displayName: 'Raikou',
   pokedexNumber: 243,
   specialty: 'skill',
@@ -644,7 +629,6 @@ export const RAIKOU: Pokemon = basePokemon({
 });
 
 export const ENTEI: Pokemon = basePokemon({
-  name: 'ENTEI',
   displayName: 'Entei',
   pokedexNumber: 244,
   specialty: 'skill',
@@ -670,7 +654,6 @@ export const ENTEI: Pokemon = basePokemon({
 });
 
 export const SUICUNE: Pokemon = basePokemon({
-  name: 'SUICUNE',
   displayName: 'Suicune',
   pokedexNumber: 245,
   specialty: 'skill',
@@ -696,7 +679,6 @@ export const SUICUNE: Pokemon = basePokemon({
 });
 
 export const RALTS: Pokemon = basePokemon({
-  name: 'RALTS',
   displayName: 'Ralts',
   pokedexNumber: 280,
   specialty: 'skill',
@@ -744,7 +726,6 @@ export const GARDEVOIR: Pokemon = {
 };
 
 export const SABLEYE: Pokemon = basePokemon({
-  name: 'SABLEYE',
   displayName: 'Sableye',
   pokedexNumber: 302,
   specialty: 'skill',
@@ -770,7 +751,6 @@ export const SABLEYE: Pokemon = basePokemon({
 });
 
 export const GULPIN: Pokemon = basePokemon({
-  name: 'GULPIN',
   displayName: 'Gulpin',
   pokedexNumber: 316,
   specialty: 'skill',
@@ -829,7 +809,6 @@ export const BONSLY: Pokemon = {
 };
 
 export const DRIFLOON: Pokemon = basePokemon({
-  name: 'DRIFLOON',
   displayName: 'Drifloon',
   pokedexNumber: 425,
   specialty: 'skill',
@@ -877,7 +856,6 @@ export const HONCHKROW: Pokemon = {
 };
 
 export const RIOLU: Pokemon = basePokemon({
-  name: 'RIOLU',
   displayName: 'Riolu',
   pokedexNumber: 447,
   specialty: 'skill',
@@ -976,7 +954,6 @@ export const GALLADE: Pokemon = {
 };
 
 export const CRESSELIA: Pokemon = basePokemon({
-  name: 'CRESSELIA',
   displayName: 'Cresselia',
   pokedexNumber: 488,
   specialty: 'skill',
@@ -1002,7 +979,6 @@ export const CRESSELIA: Pokemon = basePokemon({
 });
 
 export const RUFFLET: Pokemon = basePokemon({
-  name: 'RUFFLET',
   displayName: 'Rufflet',
   pokedexNumber: 627,
   specialty: 'skill',
@@ -1052,7 +1028,6 @@ export const SYLVEON: Pokemon = {
 };
 
 export const DEDENNE: Pokemon = basePokemon({
-  name: 'DEDENNE',
   displayName: 'Dedenne',
   pokedexNumber: 702,
   specialty: 'skill',
@@ -1078,7 +1053,6 @@ export const DEDENNE: Pokemon = basePokemon({
 });
 
 export const MIMIKYU: Pokemon = basePokemon({
-  name: 'MIMIKYU',
   displayName: 'Mimikyu',
   pokedexNumber: 778,
   specialty: 'skill',
@@ -1104,7 +1078,6 @@ export const MIMIKYU: Pokemon = basePokemon({
 });
 
 export const PAWMI: Pokemon = basePokemon({
-  name: 'PAWMI',
   displayName: 'Pawmi',
   pokedexNumber: 921,
   specialty: 'skill',

--- a/common/src/utils/ingredient-utils/ingredient-utils.ts
+++ b/common/src/utils/ingredient-utils/ingredient-utils.ts
@@ -11,7 +11,7 @@ import {
   LOCKED_INGREDIENT,
   TOTAL_NUMBER_OF_INGREDIENTS
 } from '../../types/ingredient/ingredients';
-import type { Pokemon } from '../../types/pokemon/pokemon';
+import type { Pokemon, PokemonSpecialty } from '../../types/pokemon/pokemon';
 import { emptyIngredientInventoryFloat, emptyIngredientInventoryInt } from '../flat-utils';
 import { MathUtils } from '../math-utils/math-utils';
 import { capitalize } from '../string-utils/string-utils';
@@ -259,4 +259,16 @@ export function getMaxIngredientBonus(ingredientName: string): number {
     return 0;
   }
   return bonus;
+}
+
+export function getIngredientAmount(
+  ingredientDrop: Ingredient,
+  ingredientA: Ingredient,
+  level: 0 | 30 | 60,
+  specialty: PokemonSpecialty
+) {
+  const baseStrength = ingredientA.value;
+  const levelFactor = level === 0 ? 1 : level === 30 ? 2.25 : 3.6;
+  const specialtyFactor = specialty === 'ingredient' || specialty === 'all' ? 2 : 1;
+  return Math.round((baseStrength * levelFactor * specialtyFactor) / ingredientDrop.value);
 }

--- a/common/src/utils/pokemon-utils/pokemon-utils.ts
+++ b/common/src/utils/pokemon-utils/pokemon-utils.ts
@@ -3,7 +3,6 @@ import type { Pokemon, PokemonSpecialty, PokemonWithIngredients } from '../../ty
 import { COMPLETE_POKEDEX } from '../../types/pokemon';
 
 export function basePokemon(params: {
-  name: string;
   displayName: string;
   pokedexNumber: number;
   specialty: PokemonSpecialty;
@@ -21,7 +20,6 @@ export function basePokemon(params: {
   skill: Mainskill;
 }): Pokemon {
   const {
-    name,
     displayName,
     pokedexNumber,
     specialty,
@@ -39,7 +37,11 @@ export function basePokemon(params: {
     skill
   } = params;
   return {
-    name,
+    name: displayName
+      .toUpperCase()
+      .replace(/\bFORM\b/, '')
+      .replace(/\b\W+\b/, '_')
+      .replace(/\W+/, ''),
     displayName,
     pokedexNumber,
     specialty,

--- a/common/src/utils/pokemon-utils/pokemon-utils.ts
+++ b/common/src/utils/pokemon-utils/pokemon-utils.ts
@@ -1,6 +1,7 @@
-import type { Berry, GenderRatio, IngredientSet, Mainskill } from '../../types';
+import type { Berry, GenderRatio, Ingredient, IngredientSet, Mainskill } from '../../types';
 import type { Pokemon, PokemonSpecialty, PokemonWithIngredients } from '../../types/pokemon';
 import { COMPLETE_POKEDEX } from '../../types/pokemon';
+import { getIngredientAmount } from '../ingredient-utils';
 
 export function basePokemon(params: {
   displayName: string;
@@ -14,9 +15,12 @@ export function basePokemon(params: {
   carrySize: number;
   previousEvolutions: number;
   remainingEvolutions: number;
-  ingredient0: IngredientSet[];
-  ingredient30: IngredientSet[];
-  ingredient60: IngredientSet[];
+  ingredient0?: IngredientSet[];
+  ingredient30?: IngredientSet[];
+  ingredient60?: IngredientSet[];
+  ingredientA?: Ingredient;
+  ingredientB?: Ingredient;
+  ingredientC?: Ingredient;
   skill: Mainskill;
 }): Pokemon {
   const {
@@ -34,8 +38,44 @@ export function basePokemon(params: {
     ingredient0,
     ingredient30,
     ingredient60,
+    ingredientA,
+    ingredientB,
+    ingredientC,
     skill
   } = params;
+  const abcSpecified = ingredientA !== undefined && ingredientB !== undefined;
+  const dropsSpecified = ingredient0 !== undefined && ingredient30 !== undefined && ingredient60 !== undefined;
+  if (abcSpecified === dropsSpecified) {
+    throw new Error(
+      'Expected either AB(C) ingredients or 0/30/60 ingredient sets to be specified. Got both or neither.'
+    );
+  }
+  let ingredient0Normalized: IngredientSet[];
+  let ingredient30Normalized: IngredientSet[];
+  let ingredient60Normalized: IngredientSet[];
+  if (ingredient0 && ingredient30 && ingredient60) {
+    ingredient0Normalized = ingredient0;
+    ingredient30Normalized = ingredient30;
+    ingredient60Normalized = ingredient60;
+  } else if (ingredientA && ingredientB) {
+    ingredient0Normalized = [
+      { amount: getIngredientAmount(ingredientA, ingredientA, 0, specialty), ingredient: ingredientA }
+    ];
+    ingredient30Normalized = [
+      { amount: getIngredientAmount(ingredientA, ingredientA, 30, specialty), ingredient: ingredientA },
+      { amount: getIngredientAmount(ingredientB, ingredientA, 30, specialty), ingredient: ingredientB }
+    ];
+    ingredient60Normalized = [
+      { amount: getIngredientAmount(ingredientA, ingredientA, 60, specialty), ingredient: ingredientA },
+      { amount: getIngredientAmount(ingredientB, ingredientA, 60, specialty), ingredient: ingredientB }
+    ];
+    if (ingredientC) {
+      ingredient60Normalized.push({
+        amount: getIngredientAmount(ingredientC, ingredientA, 60, specialty),
+        ingredient: ingredientC
+      });
+    }
+  }
   return {
     name: displayName
       .toUpperCase()
@@ -53,9 +93,9 @@ export function basePokemon(params: {
     carrySize,
     previousEvolutions,
     remainingEvolutions,
-    ingredient0,
-    ingredient30,
-    ingredient60,
+    ingredient0: ingredient0Normalized,
+    ingredient30: ingredient30Normalized,
+    ingredient60: ingredient60Normalized,
     skill
   };
 }

--- a/common/src/utils/pokemon-utils/pokemon-utils.ts
+++ b/common/src/utils/pokemon-utils/pokemon-utils.ts
@@ -1,5 +1,62 @@
-import type { Pokemon, PokemonWithIngredients } from '../../types/pokemon';
+import type { Berry, GenderRatio, IngredientSet, Mainskill } from '../../types';
+import type { Pokemon, PokemonSpecialty, PokemonWithIngredients } from '../../types/pokemon';
 import { COMPLETE_POKEDEX } from '../../types/pokemon';
+
+export function basePokemon(params: {
+  name: string;
+  displayName: string;
+  pokedexNumber: number;
+  specialty: PokemonSpecialty;
+  frequency: number;
+  ingredientPercentage: number;
+  skillPercentage: number;
+  berry: Berry;
+  genders: GenderRatio;
+  carrySize: number;
+  previousEvolutions: number;
+  remainingEvolutions: number;
+  ingredient0: IngredientSet[];
+  ingredient30: IngredientSet[];
+  ingredient60: IngredientSet[];
+  skill: Mainskill;
+}): Pokemon {
+  const {
+    name,
+    displayName,
+    pokedexNumber,
+    specialty,
+    frequency,
+    ingredientPercentage,
+    skillPercentage,
+    berry,
+    genders,
+    carrySize,
+    previousEvolutions,
+    remainingEvolutions,
+    ingredient0,
+    ingredient30,
+    ingredient60,
+    skill
+  } = params;
+  return {
+    name,
+    displayName,
+    pokedexNumber,
+    specialty,
+    frequency,
+    ingredientPercentage,
+    skillPercentage,
+    berry,
+    genders,
+    carrySize,
+    previousEvolutions,
+    remainingEvolutions,
+    ingredient0,
+    ingredient30,
+    ingredient60,
+    skill
+  };
+}
 
 export function getPokemon(name: string): Pokemon {
   const pkmn = COMPLETE_POKEDEX.find((pokemon) => pokemon.name.toLowerCase() === name.toLowerCase());

--- a/common/src/vitest/mocks/pokemon/mock-pokemon.ts
+++ b/common/src/vitest/mocks/pokemon/mock-pokemon.ts
@@ -3,6 +3,7 @@ import { BALANCED_GENDER } from '../../../types/gender/gender';
 import { SLOWPOKE_TAIL } from '../../../types/ingredient/ingredients';
 import { Mainskill } from '../../../types/mainskill/mainskill';
 import type { Pokemon } from '../../../types/pokemon/pokemon';
+import { basePokemon } from '../../../utils';
 
 export const mockMainskill = new (class extends Mainskill {
   name = 'mock skill';
@@ -16,7 +17,7 @@ export const mockMainskill = new (class extends Mainskill {
 })(false, true);
 
 export function mockPokemon(attrs?: Partial<Pokemon>): Pokemon {
-  return {
+  const base: Pokemon = basePokemon({
     name: 'MOCKEMON',
     displayName: 'Mockemon',
     pokedexNumber: 0,
@@ -32,7 +33,10 @@ export function mockPokemon(attrs?: Partial<Pokemon>): Pokemon {
     ingredient0: [{ amount: 0, ingredient: SLOWPOKE_TAIL }],
     ingredient30: [{ amount: 0, ingredient: SLOWPOKE_TAIL }],
     ingredient60: [{ amount: 0, ingredient: SLOWPOKE_TAIL }],
-    skill: mockMainskill,
+    skill: mockMainskill
+  });
+  return {
+    ...base,
     ...attrs
   };
 }

--- a/common/src/vitest/mocks/pokemon/mock-pokemon.ts
+++ b/common/src/vitest/mocks/pokemon/mock-pokemon.ts
@@ -18,7 +18,6 @@ export const mockMainskill = new (class extends Mainskill {
 
 export function mockPokemon(attrs?: Partial<Pokemon>): Pokemon {
   const base: Pokemon = basePokemon({
-    name: 'MOCKEMON',
     displayName: 'Mockemon',
     pokedexNumber: 0,
     specialty: 'berry',


### PR DESCRIPTION
Add a util function for creating Pokemon. The primary motivation for this is to allow us to specify A/B(/C) ingredients for Pokemon, rather than needing to specify amounts at each level. Darkrai is a special case and doesn't follow the normal rules, so the function should allow putting in the full `IngredientSet[]` versions as well.

Recently, @matt063481 [suggested on Discord](https://discord.com/channels/1300099710996058252/1332444692188762112/1394064394551427293) adding a Pokedex page to the site. If we have this util function, I think we'd be able to more easily set evolution data for each Pokemon. The util function can set new fields `previousForm` and `nextForms` to `undefined` and `[]`, and the existing evolution utilities can mutate the inputs to store names of mons in the evolutionary line.