### PR TITLE
Update backend.md to include database name in the example `.env` file

### DIFF
--- a/docs/components/backend.md
+++ b/docs/components/backend.md
@@ -12,6 +12,7 @@ DB_PORT=3306
 DB_USER=root
 DB_PASS=admin
 DATABASE_MIGRATION="UP"
+DATABASE_NAME="pokemonsleep"
 ```
 
 Then start the database (MySQL) with docker compose, run this inside the backend folder:


### PR DESCRIPTION
This is a minor PR that updates the example `.env` file for the backend to include the database name. The app seems to expect it when setting it up for the first time.