### PR TITLE
Replace ext with dto

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -148,7 +148,7 @@ Example:
 ```typescript
 // Good - using mock factory
 import { mocks } from '@/vitest';
-const pokemon = mocks.pokemonInstanceExt({ level: 50 });
+const pokemon = mocks.pokemonInstance({ level: 50 });
 
 // Bad - hard-coded inline mock
 const pokemon = { level: 50, name: 'Test' } as any;

--- a/backend/src/controllers/calculator/production.controller.ts
+++ b/backend/src/controllers/calculator/production.controller.ts
@@ -21,7 +21,7 @@ import type {
   CalculateIvRequest,
   CalculateTeamRequest,
   IngredientIndexToFloatAmount,
-  IngredientInstance,
+  IngredientInstanceDto,
   IngredientSet,
   IslandInstance,
   IslandInstanceDto,
@@ -29,9 +29,9 @@ import type {
   PokemonInstanceIdentity,
   RecipeFlat,
   SingleProductionRequest,
-  TeamMemberExt,
+  TeamMember,
   TeamSettings,
-  TeamSettingsExt
+  TeamSettingsDto
 } from 'sleepapi-common';
 import {
   calculateRecipeValue,
@@ -139,10 +139,10 @@ export default class ProductionController {
   }
 
   async #parseSettings(params: {
-    settings: TeamSettings;
+    settings: TeamSettingsDto;
     includeCooking: boolean;
     maybeUser?: DBUser;
-  }): Promise<TeamSettingsExt> {
+  }): Promise<TeamSettings> {
     const { settings, includeCooking, maybeUser } = params;
 
     const camp = queryAsBoolean(settings.camp);
@@ -205,7 +205,7 @@ export default class ProductionController {
   }
 
   #parseTeamMembers(members: PokemonInstanceIdentity[], camp: boolean) {
-    const parsedMembers: TeamMemberExt[] = [];
+    const parsedMembers: TeamMember[] = [];
     for (const member of members) {
       const pokemon = getPokemon(member.pokemon);
       const subskills = new Set(
@@ -241,7 +241,11 @@ export default class ProductionController {
     return parsedMembers;
   }
 
-  #getIngredientSet(params: { pokemon: Pokemon; level: number; ingredients: IngredientInstance[] }): IngredientSet[] {
+  #getIngredientSet(params: {
+    pokemon: Pokemon;
+    level: number;
+    ingredients: IngredientInstanceDto[];
+  }): IngredientSet[] {
     const { ingredients, level } = params;
     const result: IngredientSet[] = [];
 

--- a/backend/src/controllers/solve/solve.controller.test.ts
+++ b/backend/src/controllers/solve/solve.controller.test.ts
@@ -15,7 +15,7 @@ describe('solve.controller', () => {
     });
 
     it('should enrich solve settings with valid inputs', () => {
-      const settings = mocks.solveSettings();
+      const settings = mocks.solveSettingsDto();
 
       const enrichSolveSettings = controller._testAccess().enrichSolveSettings;
       const result = enrichSolveSettings(settings);
@@ -36,7 +36,7 @@ describe('solve.controller', () => {
     });
 
     it('should map expert mode settings when provided', () => {
-      const settings = mocks.solveSettings({
+      const settings = mocks.solveSettingsDto({
         island: mocks.islandInstance({
           expert: true,
           berries: [common.berry.ORAN, common.berry.MAGO],
@@ -55,7 +55,7 @@ describe('solve.controller', () => {
     });
 
     it('should throw BadRequestError for invalid sleep duration', () => {
-      const settings = mocks.solveSettings({ wakeup: '12:00', bedtime: '12:01' });
+      const settings = mocks.solveSettingsDto({ wakeup: '12:00', bedtime: '12:01' });
 
       const enrichSolveSettings = controller._testAccess().enrichSolveSettings;
 
@@ -71,7 +71,7 @@ describe('solve.controller', () => {
     });
 
     it('should enrich member settings with valid inputs', () => {
-      const settings = mocks.teamMemberSettings();
+      const settings = mocks.teamMemberSettingsDto();
 
       const natureMock = vimic(common, 'getNature', () => common.nature.BASHFUL);
 

--- a/backend/src/controllers/solve/solve.controller.ts
+++ b/backend/src/controllers/solve/solve.controller.ts
@@ -13,11 +13,11 @@ import type {
   SolveRecipeRequest,
   SolveRecipeResponse,
   SolveSettings,
-  SolveSettingsExt,
+  SolveSettingsDto,
   SurplusIngredients,
-  TeamMemberExt,
+  TeamMember,
   TeamMemberSettings,
-  TeamMemberSettingsExt,
+  TeamMemberSettingsDto,
   TeamMemberWithProduce
 } from 'sleepapi-common';
 import {
@@ -42,12 +42,12 @@ export default class SolveController {
     return this.resultToResponse(result, name);
   }
 
-  public solveIngredient(name: string, settings: SolveSettings) {
+  public solveIngredient(name: string, settings: SolveSettingsDto) {
     return SolveService.solveIngredient(getIngredient(name), this.enrichSolveSettings(settings));
   }
 
   private parseInput(input: SolveRecipeRequest): SolveRecipeInput {
-    const includedMembers: TeamMemberExt[] =
+    const includedMembers: TeamMember[] =
       input.includedMembers?.map((member) => {
         const pokemon = getPokemon(member.pokemonWithIngredients.pokemon);
         return {
@@ -66,7 +66,7 @@ export default class SolveController {
     };
   }
 
-  private enrichSolveSettings(settings: SolveSettings): SolveSettingsExt {
+  private enrichSolveSettings(settings: SolveSettingsDto): SolveSettings {
     const { camp, level } = settings;
     const bedtime = parseTime(settings.bedtime);
     const wakeup = parseTime(settings.wakeup);
@@ -105,7 +105,7 @@ export default class SolveController {
     }
   }
 
-  private enrichMemberSettings(settings: TeamMemberSettings): TeamMemberSettingsExt {
+  private enrichMemberSettings(settings: TeamMemberSettingsDto): TeamMemberSettings {
     const { level, carrySize, externalId, ribbon, skillLevel, sneakySnacking } = settings;
     const subskills = new Set(settings.subskills);
     const nature = getNature(settings.nature);

--- a/backend/src/database/dao/pokemon/pokemon-dao.test.ts
+++ b/backend/src/database/dao/pokemon/pokemon-dao.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { PokemonDAO } from '@src/database/dao/pokemon/pokemon-dao.js';
 import { DaoFixture } from '@src/utils/test-utils/dao-fixture.js';
-import type { IngredientInstance, SubskillInstance } from 'sleepapi-common';
+import type { IngredientInstanceDto, SubskillInstanceDto } from 'sleepapi-common';
 import { uuid } from 'sleepapi-common';
 import { vimic } from 'vimic';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -324,7 +324,7 @@ describe('filterFilledSubskills', () => {
 
 describe('subskillForLevel', () => {
   it('shall return the subskill matching the level', () => {
-    const subskills: SubskillInstance[] = [
+    const subskills: SubskillInstanceDto[] = [
       { level: 1, subskill: 'subskill1' },
       {
         level: 2,
@@ -339,7 +339,7 @@ describe('subskillForLevel', () => {
 
 describe('ingredientForLevel', () => {
   it('shall return the ingredient matching the level', () => {
-    const ingredients: IngredientInstance[] = [
+    const ingredients: IngredientInstanceDto[] = [
       { level: 1, name: 'ingredient1', amount: 2 },
       { level: 2, name: 'ingredient2', amount: 5 }
     ];

--- a/backend/src/database/dao/pokemon/pokemon-dao.ts
+++ b/backend/src/database/dao/pokemon/pokemon-dao.ts
@@ -2,7 +2,7 @@ import type { Static } from '@sinclair/typebox';
 import { Type } from '@sinclair/typebox';
 import { AbstractDAO, DBWithVersionedIdSchema } from '@src/database/dao/abstract-dao.js';
 import { IngredientError } from '@src/domain/error/ingredient/ingredient-error.js';
-import { getPokemon, type IngredientInstance, type SubskillInstance } from 'sleepapi-common';
+import { getPokemon, type IngredientInstanceDto, type SubskillInstanceDto } from 'sleepapi-common';
 
 const DBPokemonSchema = Type.Composite([
   DBWithVersionedIdSchema,
@@ -36,8 +36,8 @@ class PokemonDAOImpl extends AbstractDAO<typeof DBPokemonSchema> {
   public tableName = 'pokemon';
   public schema = DBPokemonSchema;
 
-  public filterFilledSubskills(subskills: DBPokemon): SubskillInstance[] {
-    const filledSubskills: SubskillInstance[] = [];
+  public filterFilledSubskills(subskills: DBPokemon): SubskillInstanceDto[] {
+    const filledSubskills: SubskillInstanceDto[] = [];
 
     if (subskills.subskill_10) {
       filledSubskills.push({ level: 10, subskill: subskills.subskill_10 });
@@ -58,11 +58,11 @@ class PokemonDAOImpl extends AbstractDAO<typeof DBPokemonSchema> {
     return filledSubskills;
   }
 
-  public subskillForLevel(level: number, subskills: SubskillInstance[]) {
+  public subskillForLevel(level: number, subskills: SubskillInstanceDto[]) {
     return subskills.find((subskill) => subskill.level === level)?.subskill;
   }
 
-  public ingredientForLevel(level: number, ingredients: IngredientInstance[]) {
+  public ingredientForLevel(level: number, ingredients: IngredientInstanceDto[]) {
     const ingredient = ingredients.find((ingredient) => ingredient.level === level)?.name;
     if (!ingredient) {
       throw new IngredientError('Missing required ingredient in upsert member request for level: ' + level);
@@ -70,7 +70,7 @@ class PokemonDAOImpl extends AbstractDAO<typeof DBPokemonSchema> {
     return ingredient;
   }
 
-  public filterChosenIngredientList(pokemonInstance: DBPokemon): IngredientInstance[] {
+  public filterChosenIngredientList(pokemonInstance: DBPokemon): IngredientInstanceDto[] {
     const { ingredient_0, ingredient_30, ingredient_60, pokemon } = pokemonInstance;
     const member = getPokemon(pokemon);
     return [

--- a/backend/src/database/dao/team/team/team-dao.ts
+++ b/backend/src/database/dao/team/team/team-dao.ts
@@ -13,7 +13,7 @@ import {
   type GetTeamResponse,
   type IngredientSetSimple,
   type MemberInstance,
-  type SubskillInstance
+  type SubskillInstanceDto
 } from 'sleepapi-common';
 
 const DBTeamSchema = Type.Composite([
@@ -49,7 +49,7 @@ class TeamDAOImpl extends AbstractDAO<typeof DBTeamSchema> {
       for (const memberData of memberMetaData) {
         const member: DBPokemon = await PokemonDAO.get({ id: memberData.fk_pokemon_id });
 
-        const subskills: SubskillInstance[] = [];
+        const subskills: SubskillInstanceDto[] = [];
         if (member.subskill_10) {
           subskills.push({ level: 10, subskill: member.subskill_10 });
         }

--- a/backend/src/services/api-service/production/production-service.test.ts
+++ b/backend/src/services/api-service/production/production-service.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@src/services/api-service/production/production-service.js';
 import { defaultUserRecipes } from '@src/services/simulation-service/team-simulator/cooking-state/cooking-utils.js';
 import { MOCKED_OPTIMAL_PRODUCTION_STATS } from '@src/utils/test-utils/defaults.js';
-import type { TeamMemberExt, TeamSettingsExt } from 'sleepapi-common';
+import type { TeamMember, TeamSettings } from 'sleepapi-common';
 import {
   BULBASAUR,
   CHARMANDER,
@@ -66,7 +66,7 @@ describe('calculatePokemonProduction', () => {
 
 describe('calculateTeam', () => {
   it('shall calculate production with uneven sleep times', () => {
-    const settings: TeamSettingsExt = {
+    const settings: TeamSettings = {
       bedtime: parseTime('21:30'),
       wakeup: parseTime('06:01'),
       camp: false,
@@ -76,7 +76,7 @@ describe('calculateTeam', () => {
       island: { ...DEFAULT_ISLAND }
     };
 
-    const members: TeamMemberExt[] = [
+    const members: TeamMember[] = [
       {
         pokemonWithIngredients: {
           pokemon: PINSIR,
@@ -133,7 +133,7 @@ describe('calculateTeam', () => {
 
 describe('calculateIv', () => {
   it('should calculate IVs for a given team and variants', () => {
-    const settings: TeamSettingsExt = {
+    const settings: TeamSettings = {
       bedtime: parseTime('22:00'),
       wakeup: parseTime('06:00'),
       camp: true,
@@ -143,7 +143,7 @@ describe('calculateIv', () => {
       island: { ...DEFAULT_ISLAND }
     };
 
-    const members: TeamMemberExt[] = [
+    const members: TeamMember[] = [
       {
         pokemonWithIngredients: {
           pokemon: BULBASAUR,
@@ -162,7 +162,7 @@ describe('calculateIv', () => {
       }
     ];
 
-    const variants: TeamMemberExt[] = [
+    const variants: TeamMember[] = [
       {
         pokemonWithIngredients: {
           pokemon: CHARMANDER,

--- a/backend/src/services/api-service/production/production-service.ts
+++ b/backend/src/services/api-service/production/production-service.ts
@@ -11,8 +11,8 @@ import type {
   DetailedProduce,
   MemberProductionBase,
   Pokemon,
-  TeamMemberExt,
-  TeamSettingsExt
+  TeamMember,
+  TeamSettings
 } from 'sleepapi-common';
 import { CarrySizeUtils, getAllIngredientLists, limitSubSkillsToLevel, nature, subskill } from 'sleepapi-common';
 
@@ -134,7 +134,7 @@ export function calculatePokemonProduction(
 
 // 5110 days is 14 years or 730 weeks
 export function calculateTeam(
-  params: { settings: TeamSettingsExt; members: TeamMemberExt[]; userRecipes: UserRecipes },
+  params: { settings: TeamSettings; members: TeamMember[]; userRecipes: UserRecipes },
   iterations = 5110
 ) {
   const { settings, members, userRecipes } = params;
@@ -151,7 +151,7 @@ export function calculateTeam(
 }
 
 export function calculateSimple(
-  params: { settings: TeamSettingsExt; members: TeamMemberExt[]; userRecipes: UserRecipes },
+  params: { settings: TeamSettings; members: TeamMember[]; userRecipes: UserRecipes },
   iterations = 700
 ) {
   const { settings, members, userRecipes } = params;
@@ -174,7 +174,7 @@ export function calculateSimple(
 }
 
 export function calculateIv(
-  params: { settings: TeamSettingsExt; members: TeamMemberExt[]; variants: TeamMemberExt[] },
+  params: { settings: TeamSettings; members: TeamMember[]; variants: TeamMember[] },
   iterations = 1400
 ): CalculateIvResponse {
   const { settings, members, variants } = params;

--- a/backend/src/services/notification-service/notification-service.ts
+++ b/backend/src/services/notification-service/notification-service.ts
@@ -7,10 +7,10 @@ import { NotificationType, uuid, type BaseUser, type NotificationResponse } from
 
 class NotificationServiceImpl {
   public async getNotifications(user: DBUser): Promise<NotificationResponse> {
-    const notifications = await NotificationDAO.findMultiple({ fk_receiver_id: user.id });
+    const notificationsDto = await NotificationDAO.findMultiple({ fk_receiver_id: user.id });
 
-    const notificationsExt: UserNotification[] = [];
-    for (const notification of notifications) {
+    const notifications: UserNotification[] = [];
+    for (const notification of notificationsDto) {
       const senderRaw = await UserDAO.get({ id: notification.fk_sender_id });
       const receiverRaw = await UserDAO.get({ id: notification.fk_receiver_id });
 
@@ -25,10 +25,10 @@ class NotificationServiceImpl {
       const template = notification.template;
       if (template === NotificationType.News) {
         const news = await this.getNewsNotification(notification);
-        notificationsExt.push({ sender, receiver, template, news, externalId });
-      } else notificationsExt.push({ sender, receiver, template, externalId });
+        notifications.push({ sender, receiver, template, news, externalId });
+      } else notifications.push({ sender, receiver, template, externalId });
     }
-    return { notifications: notificationsExt };
+    return { notifications: notifications };
   }
 
   public async dismissNotification(externalId: string) {

--- a/backend/src/services/simulation-service/team-simulator/cooking-state/cooking-state.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/cooking-state/cooking-state.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from 'vitest';
 describe('CookingState', () => {
   it('shall include provided meal times in results', () => {
     const cookingState = new CookingState(
-      mocks.teamSettingsExt({ camp: true }),
+      mocks.teamSettings({ camp: true }),
       defaultUserRecipes(),
       createPreGeneratedRandom()
     );
@@ -36,7 +36,7 @@ describe('CookingState', () => {
 
   it('shall cook the best recipe for which it has ingredients', () => {
     const cookingState = new CookingState(
-      mocks.teamSettingsExt({ camp: true, potSize: MAX_POT_SIZE }),
+      mocks.teamSettings({ camp: true, potSize: MAX_POT_SIZE }),
       defaultUserRecipes(),
       createPreGeneratedRandom()
     );
@@ -60,7 +60,7 @@ describe('CookingState', () => {
 
   it('shall fallback to mixed meal if team cant cook', () => {
     const cookingState = new CookingState(
-      mocks.teamSettingsExt({ camp: true }),
+      mocks.teamSettings({ camp: true }),
       defaultUserRecipes(),
       createPreGeneratedRandom()
     );
@@ -87,7 +87,7 @@ describe('CookingState', () => {
 
   it('shall cook mixed meal if team cant cook better', () => {
     const cookingState = new CookingState(
-      mocks.teamSettingsExt({ camp: true }),
+      mocks.teamSettings({ camp: true }),
       defaultUserRecipes(),
       createPreGeneratedRandom()
     );
@@ -116,7 +116,7 @@ describe('CookingState', () => {
 
   it('shall crit with max bonus on sunday', () => {
     const cookingState = new CookingState(
-      mocks.teamSettingsExt({ camp: true, potSize: MAX_POT_SIZE }),
+      mocks.teamSettings({ camp: true, potSize: MAX_POT_SIZE }),
       defaultUserRecipes(),
       createPreGeneratedRandom()
     );
@@ -137,7 +137,7 @@ describe('CookingState', () => {
 
   it('shall be able to cook macarons with pot skill proc', () => {
     const cookingState = new CookingState(
-      mocks.teamSettingsExt({ camp: true, potSize: MAX_POT_SIZE }),
+      mocks.teamSettings({ camp: true, potSize: MAX_POT_SIZE }),
       defaultUserRecipes(),
       createPreGeneratedRandom()
     );
@@ -159,7 +159,7 @@ describe('CookingState', () => {
       { amount: 5, ingredient: ingredient.BEAN_SAUSAGE }
     ]);
     const cookingState = new CookingState(
-      mocks.teamSettingsExt({ camp: true, stockpiledIngredients: initialStockpile }),
+      mocks.teamSettings({ camp: true, stockpiledIngredients: initialStockpile }),
       defaultUserRecipes(),
       createPreGeneratedRandom()
     );

--- a/backend/src/services/simulation-service/team-simulator/cooking-state/cooking-state.ts
+++ b/backend/src/services/simulation-service/team-simulator/cooking-state/cooking-state.ts
@@ -8,7 +8,7 @@ import type {
   CookingResult,
   IngredientIndexToFloatAmount,
   MealTimes,
-  TeamSettingsExt
+  TeamSettings
 } from 'sleepapi-common';
 import { curry, dessert, emptyIngredientInventoryFloat, flatToIngredientSet, ingredient, salad } from 'sleepapi-common';
 
@@ -57,7 +57,7 @@ export class CookingState {
   private currentSaladStockpile: IngredientIndexToFloatAmount;
   private currentDessertStockpile: IngredientIndexToFloatAmount;
 
-  constructor(settings: TeamSettingsExt, userRecipes: UserRecipes, rng: PreGeneratedRandom) {
+  constructor(settings: TeamSettings, userRecipes: UserRecipes, rng: PreGeneratedRandom) {
     const { curries, salads, desserts } = userRecipes;
     this.userCurries = curries;
     this.userSalads = salads;

--- a/backend/src/services/simulation-service/team-simulator/member-state/member-state.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/member-state/member-state.test.ts
@@ -6,7 +6,7 @@ import { TeamSimulatorUtils } from '@src/services/simulation-service/team-simula
 import type { PreGeneratedRandom } from '@src/utils/random-utils/pre-generated-random.js';
 import { createPreGeneratedRandom } from '@src/utils/random-utils/pre-generated-random.js';
 import { mocks } from '@src/vitest/index.js';
-import type { IngredientSet, PokemonWithIngredients, TeamMemberExt, TeamSettingsExt } from 'sleepapi-common';
+import type { IngredientSet, PokemonWithIngredients, TeamMember, TeamSettings } from 'sleepapi-common';
 import {
   berry,
   ChargeStrengthM,
@@ -42,7 +42,7 @@ const mockPokemonSet: PokemonWithIngredients = {
   ]
 };
 
-const guaranteedSkillProcMember: TeamMemberExt = {
+const guaranteedSkillProcMember: TeamMember = {
   pokemonWithIngredients: { ...mockPokemonSet, pokemon: { ...mockPokemonSet.pokemon, skillPercentage: 100 } },
   settings: {
     carrySize: 10,
@@ -56,7 +56,7 @@ const guaranteedSkillProcMember: TeamMemberExt = {
   }
 };
 
-const member: TeamMemberExt = {
+const member: TeamMember = {
   pokemonWithIngredients: mockPokemonSet,
   settings: {
     carrySize: 10,
@@ -70,7 +70,7 @@ const member: TeamMemberExt = {
   }
 };
 
-const sneakySnackingMember: TeamMemberExt = {
+const sneakySnackingMember: TeamMember = {
   pokemonWithIngredients: guaranteedSkillProcMember.pokemonWithIngredients,
   settings: {
     ...guaranteedSkillProcMember.settings,
@@ -78,7 +78,7 @@ const sneakySnackingMember: TeamMemberExt = {
   }
 };
 
-const settings: TeamSettingsExt = {
+const settings: TeamSettings = {
   bedtime: parseTime('21:30'),
   wakeup: parseTime('06:00'),
   camp: false,
@@ -247,7 +247,7 @@ describe('startDay', () => {
   });
 
   it('shall recover less than full sleep if energy- nature', () => {
-    const member: TeamMemberExt = {
+    const member: TeamMember = {
       pokemonWithIngredients: mockPokemonSet,
       settings: {
         carrySize: 10,
@@ -269,7 +269,7 @@ describe('startDay', () => {
   });
 
   it('shall recover less than full sleep if sleeping short', () => {
-    const member: TeamMemberExt = {
+    const member: TeamMember = {
       pokemonWithIngredients: mockPokemonSet,
       settings: {
         carrySize: 10,
@@ -283,7 +283,7 @@ describe('startDay', () => {
       }
     };
 
-    const settings: TeamSettingsExt = mocks.teamSettingsExt({ bedtime: parseTime('23:30') });
+    const settings: TeamSettings = mocks.teamSettings({ bedtime: parseTime('23:30') });
 
     const memberState = new MemberState({ member, settings, team: [member], cookingState });
     expect(memberState.energy).toBe(0);
@@ -303,7 +303,7 @@ describe('startDay', () => {
   });
 
   it('shall recover to 100 despite energy- nature if teammate has erb', () => {
-    const member: TeamMemberExt = {
+    const member: TeamMember = {
       pokemonWithIngredients: mockPokemonSet,
       settings: {
         carrySize: 10,
@@ -316,7 +316,7 @@ describe('startDay', () => {
         sneakySnacking: false
       }
     };
-    const teammate: TeamMemberExt = {
+    const teammate: TeamMember = {
       ...member,
       settings: {
         ...member.settings,
@@ -332,7 +332,7 @@ describe('startDay', () => {
   });
 
   it('shall recover to 105 if member has erb', () => {
-    const member: TeamMemberExt = {
+    const member: TeamMember = {
       pokemonWithIngredients: mockPokemonSet,
       settings: {
         carrySize: 10,
@@ -365,7 +365,7 @@ describe('recoverEnergy', () => {
   });
 
   it('shall recover less energy with energy- nature', () => {
-    const member: TeamMemberExt = {
+    const member: TeamMember = {
       pokemonWithIngredients: mockPokemonSet,
       settings: {
         carrySize: 10,
@@ -447,9 +447,9 @@ describe('recoverMeal', () => {
 
 describe('attemptDayHelp', () => {
   it('shall perform a help if time surpasses scheduled help time', () => {
-    const settings: TeamSettingsExt = mocks.teamSettingsExt({ bedtime: parseTime('23:30') });
+    const settings: TeamSettings = mocks.teamSettings({ bedtime: parseTime('23:30') });
 
-    const member: TeamMemberExt = {
+    const member: TeamMember = {
       pokemonWithIngredients: { ...mockPokemonSet, pokemon: { ...mockPokemonSet.pokemon, skillPercentage: 0 } },
       settings: {
         carrySize: 10,
@@ -473,7 +473,7 @@ describe('attemptDayHelp', () => {
   });
 
   it('shall not perform a help if time has not passed scheduled help time', () => {
-    const settings: TeamSettingsExt = mocks.teamSettingsExt({ bedtime: parseTime('23:30') });
+    const settings: TeamSettings = mocks.teamSettings({ bedtime: parseTime('23:30') });
 
     const memberState = new MemberState({ member, settings, team: [member], cookingState });
     memberState.wakeUp();
@@ -485,7 +485,7 @@ describe('attemptDayHelp', () => {
   });
 
   it('shall schedule the next help', () => {
-    const settings: TeamSettingsExt = mocks.teamSettingsExt();
+    const settings: TeamSettings = mocks.teamSettings();
 
     const memberState = new MemberState({ member, settings, team: [member], cookingState });
     memberState.wakeUp();
@@ -541,7 +541,7 @@ describe('attemptDayHelp', () => {
   });
 
   it('shall still count metronome proc as 1 proc', () => {
-    const member: TeamMemberExt = {
+    const member: TeamMember = {
       pokemonWithIngredients: {
         ...mockPokemonSet,
         pokemon: { ...mockPokemonSet.pokemon, skillPercentage: 100, skill: Metronome }
@@ -588,7 +588,7 @@ describe('attemptNightHelp', () => {
   });
 
   it('shall add any excess helps to sneaky snacking, and shall not roll skill proc on those', () => {
-    const noCarryMember: TeamMemberExt = { ...member, settings: { ...member.settings, carrySize: 0 } };
+    const noCarryMember: TeamMember = { ...member, settings: { ...member.settings, carrySize: 0 } };
     const memberState = new MemberState({ member: noCarryMember, settings, team: [noCarryMember], cookingState });
     memberState.wakeUp();
     memberState.collectInventory();
@@ -602,7 +602,7 @@ describe('attemptNightHelp', () => {
   });
 
   it('shall roll skill proc on helps before inventory full at night, upon collecting in the morning', () => {
-    const member: TeamMemberExt = {
+    const member: TeamMember = {
       pokemonWithIngredients: { ...mockPokemonSet, pokemon: { ...mockPokemonSet.pokemon, skillPercentage: 100 } },
       settings: {
         carrySize: 10,
@@ -677,7 +677,7 @@ describe('expert mode ingredient bonus', () => {
   }
 
   // Forces every roll to produce an ingredient by maxing ingredientPercentage.
-  const ingredientFavoredMember = (overrides?: Partial<PokemonWithIngredients['pokemon']>): TeamMemberExt => ({
+  const ingredientFavoredMember = (overrides?: Partial<PokemonWithIngredients['pokemon']>): TeamMember => ({
     pokemonWithIngredients: {
       ...mockPokemonSet,
       pokemon: commonMocks.mockPokemon({
@@ -710,7 +710,7 @@ describe('expert mode ingredient bonus', () => {
     randomBonus: 'ingredient' | 'berry' | 'skill',
     main = berry.BELUE,
     subs: (typeof berry.BELUE)[] = []
-  ): TeamSettingsExt => ({
+  ): TeamSettings => ({
     ...settings,
     island: commonMocks.islandInstance({
       expert: true,

--- a/backend/src/services/simulation-service/team-simulator/member-state/member-state.ts
+++ b/backend/src/services/simulation-service/team-simulator/member-state/member-state.ts
@@ -24,8 +24,8 @@ import type {
   PokemonWithIngredientsIndexed,
   Produce,
   SimpleTeamResult,
-  TeamMemberExt,
-  TeamSettingsExt,
+  TeamMember,
+  TeamSettings,
   TimePeriod
 } from 'sleepapi-common';
 import {
@@ -54,12 +54,12 @@ import { StrengthCalculator } from '../strength-calculator/strength-calculator.j
 export type HelpPeriod = 'day' | 'night';
 
 export class MemberState {
-  member: TeamMemberExt;
-  team: TeamMemberExt[];
+  member: TeamMember;
+  team: TeamMember[];
   otherMembers: MemberState[] = [];
   cookingState?: CookingState;
   private skillState: SkillState;
-  private settings: TeamSettingsExt;
+  private settings: TeamSettings;
   private camp: boolean;
   private rng: PreGeneratedRandom;
 
@@ -151,9 +151,9 @@ export class MemberState {
   private expertIngredientSpecialistBonus = false;
 
   constructor(params: {
-    member: TeamMemberExt;
-    team: TeamMemberExt[];
-    settings: TeamSettingsExt;
+    member: TeamMember;
+    team: TeamMember[];
+    settings: TeamSettings;
     cookingState: CookingState | undefined;
     iterations?: number;
     rng?: PreGeneratedRandom;

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/berry-burst/berry-burst-draco-meteor-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/berry-burst/berry-burst-draco-meteor-effect.test.ts
@@ -13,7 +13,7 @@ describe('BerryBurstDracoMeteorEffect', () => {
 
   beforeEach(() => {
     memberState = mocks.memberState({
-      member: mocks.teamMemberExt({
+      member: mocks.teamMember({
         pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: LATIOS })
       })
     });
@@ -64,7 +64,7 @@ describe('BerryBurstDracoMeteorEffect', () => {
     const preExistingSkillProduce = mocks.produce();
     memberState.otherMembers = [
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: LATIAS })
         })
       })
@@ -150,28 +150,28 @@ describe('BerryBurstDracoMeteorEffect', () => {
 
     memberState.otherMembers = [
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: 'same-berry-1', berry: LATIOS.berry })
           })
         })
       }),
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: 'same-berry-2', berry: LATIOS.berry })
           })
         })
       }),
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: 'off-berry-1' })
           })
         })
       }),
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: 'off-berry-2' })
           })
@@ -222,26 +222,26 @@ describe('BerryBurstDracoMeteorEffect', () => {
 
     memberState.otherMembers = [
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: LATIAS })
         })
       }),
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: 'same-berry-1', berry: LATIOS.berry })
           })
         })
       }),
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: 'same-berry-2', berry: LATIOS.berry })
           })
         })
       }),
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: 'same-berry-3', berry: LATIOS.berry })
           })
@@ -293,24 +293,24 @@ describe('BerryBurstDracoMeteorEffect', () => {
     const duplicateSpecies = mocks.mockPokemon({ name: 'same-berry-1', berry: LATIOS.berry });
     memberState.otherMembers = [
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: duplicateSpecies })
         })
       }),
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: duplicateSpecies })
         })
       }),
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: 'off-berry-1' })
           })
         })
       }),
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: 'off-berry-2' })
           })

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/berry-burst/berry-burst-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/berry-burst/berry-burst-effect.test.ts
@@ -66,12 +66,12 @@ describe('BerryBurstEffect', () => {
   it('should add berries to inventory correctly', () => {
     memberState = mocks.memberState({
       team: [
-        mocks.teamMemberExt({
-          settings: mocks.teamMemberSettingsExt({ externalId: 'member1' }),
+        mocks.teamMember({
+          settings: mocks.teamMemberSettings({ externalId: 'member1' }),
           pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: BUTTERFREE })
         }),
-        mocks.teamMemberExt({
-          settings: mocks.teamMemberSettingsExt({ externalId: 'member1' }),
+        mocks.teamMember({
+          settings: mocks.teamMemberSettings({ externalId: 'member1' }),
           pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: NINETALES_ALOLAN })
         })
       ]

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/charge-strength-s/charge-strength-s-stockpile-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/charge-strength-s/charge-strength-s-stockpile-effect.test.ts
@@ -12,7 +12,7 @@ describe('ChargeStrengthSStockpileSEffect', () => {
     effect = new ChargeStrengthSStockpileEffect();
     mockSkillState = mocks.skillState(
       mocks.memberState({
-        member: mocks.teamMemberExt({
+        member: mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: commonMocks.mockPokemon({ skill: ChargeStrengthSStockpile })
           })

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/energy-for-everyone-s/energy-for-everyone-s-lunar-blessing-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/energy-for-everyone-s/energy-for-everyone-s-lunar-blessing-effect.test.ts
@@ -27,7 +27,7 @@ describe('EnergyForEveryoneSLunarBlessingEffect', () => {
     const expectedSelfBerryAmount = EnergyForEveryoneSLunarBlessing.selfBerries[unique][skillLevel - 1];
     const expectedTeamBerryAmount = EnergyForEveryoneSLunarBlessing.teamBerries[unique][skillLevel - 1];
 
-    const mockTeam = [mocks.teamMemberExt()];
+    const mockTeam = [mocks.teamMember()];
     Object.defineProperty(memberState, 'team', {
       get: () => mockTeam
     });
@@ -71,7 +71,7 @@ describe('EnergyForEveryoneSLunarBlessingEffect', () => {
     const team = Array(5)
       .fill(null)
       .map((_, index) =>
-        mocks.teamMemberExt({
+        mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: `member ${index}` })
           })
@@ -143,7 +143,7 @@ describe('EnergyForEveryoneSLunarBlessingEffect', () => {
     const largeTeam = Array(MAX_TEAM_SIZE + 2)
       .fill(null)
       .map((_, index) =>
-        mocks.teamMemberExt({
+        mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: mocks.mockPokemon({ name: `member ${index}` })
           })

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/extra-helpful-s/extra-helpful-s-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/extra-helpful-s/extra-helpful-s-effect.test.ts
@@ -20,7 +20,7 @@ describe('ExtraHelpfulSEffect', () => {
   it('should calculate regular amount correctly', () => {
     const regularAmount = 20;
     memberState = mocks.memberState({
-      team: [mocks.teamMemberExt(), mocks.teamMemberExt(), mocks.teamMemberExt(), mocks.teamMemberExt()]
+      team: [mocks.teamMember(), mocks.teamMember(), mocks.teamMember(), mocks.teamMember()]
     });
     skillState = mocks.skillState(memberState);
     vimic(skillState, 'skillAmount', () => regularAmount);
@@ -46,7 +46,7 @@ describe('ExtraHelpfulSEffect', () => {
     const regularAmount = 20;
     vimic(skillState, 'skillAmount', () => regularAmount);
     memberState = mocks.memberState({
-      team: [mocks.teamMemberExt()]
+      team: [mocks.teamMember()]
     });
 
     const result = extraHelpfulSEffect.activate(skillState);
@@ -70,7 +70,7 @@ describe('ExtraHelpfulSEffect', () => {
     const regularAmount = 0;
     vimic(skillState, 'skillAmount', () => regularAmount);
     memberState = mocks.memberState({
-      team: [mocks.teamMemberExt(), mocks.teamMemberExt(), mocks.teamMemberExt(), mocks.teamMemberExt()]
+      team: [mocks.teamMember(), mocks.teamMember(), mocks.teamMember(), mocks.teamMember()]
     });
 
     const result = extraHelpfulSEffect.activate(skillState);

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/helper-boost/helper-boost-effect.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-effects/helper-boost/helper-boost-effect.test.ts
@@ -45,7 +45,7 @@ describe('HelperBoostEffect', () => {
     HelperBoost.baseAmounts[0] = regularAmount;
 
     memberState = mocks.memberState({
-      team: new Array(MAX_TEAM_SIZE + 1).fill(mocks.teamMemberExt())
+      team: new Array(MAX_TEAM_SIZE + 1).fill(mocks.teamMember())
     });
     skillState = mocks.skillState(memberState);
 

--- a/backend/src/services/simulation-service/team-simulator/skill-state/skill-state.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/skill-state/skill-state.test.ts
@@ -89,7 +89,7 @@ describe('SkillState', () => {
   it('should add bonus activations correctly', () => {
     const mockPokemon = mocks.mockPokemon({ skill: BerryBurst });
     const mockPokemonWithIngredients = mocks.pokemonWithIngredients({ pokemon: mockPokemon });
-    const mockTeamMember = mocks.teamMemberExt({ pokemonWithIngredients: mockPokemonWithIngredients });
+    const mockTeamMember = mocks.teamMember({ pokemonWithIngredients: mockPokemonWithIngredients });
     mockMemberState = mocks.memberState({ member: mockTeamMember });
     skillState = mocks.skillState(mockMemberState);
 

--- a/backend/src/services/simulation-service/team-simulator/strength-calculator/strength-calculator.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/strength-calculator/strength-calculator.test.ts
@@ -7,7 +7,7 @@ describe('StrengthCalculator', () => {
   const calculator = new StrengthCalculator();
 
   it('shall calculate berry strength with favored and island bonuses', () => {
-    const settings = mocks.teamSettingsExt({
+    const settings = mocks.teamSettings({
       island: mocks.islandInstance({
         berries: [berry.BELUE],
         areaBonus: 15
@@ -47,7 +47,7 @@ describe('StrengthCalculator', () => {
   });
 
   it('shall calculate skill strength including skill berries and strength value', () => {
-    const settings = mocks.teamSettingsExt({
+    const settings = mocks.teamSettings({
       island: mocks.islandInstance({
         berries: [berry.BELUE],
         areaBonus: 20
@@ -93,7 +93,7 @@ describe('StrengthCalculator', () => {
   });
 
   it('shall apply the expert mode berry bonus to helper and skill berries and compound with area bonus', () => {
-    const settings = mocks.teamSettingsExt({
+    const settings = mocks.teamSettings({
       island: mocks.islandInstance({
         expert: true,
         berries: [berry.BELUE],
@@ -145,7 +145,7 @@ describe('StrengthCalculator', () => {
   });
 
   it('shall fall back to settings area bonus when not provided', () => {
-    const settings = mocks.teamSettingsExt({
+    const settings = mocks.teamSettings({
       island: mocks.islandInstance({
         berries: [berry.BELUE],
         areaBonus: 10

--- a/backend/src/services/simulation-service/team-simulator/strength-calculator/strength-calculator.ts
+++ b/backend/src/services/simulation-service/team-simulator/strength-calculator/strength-calculator.ts
@@ -1,11 +1,11 @@
-import type { BerrySet, MemberProduction, MemberStrength, TeamSettingsExt } from 'sleepapi-common';
+import type { BerrySet, MemberProduction, MemberStrength, TeamSettings } from 'sleepapi-common';
 import { BASE_FAVORED_BERRY_MULTIPLIER, berryPowerForLevel, EXPERT_MODE_BERRY_BONUS_MULTIPLIER } from 'sleepapi-common';
 
-type IslandBerries = Pick<TeamSettingsExt['island'], 'berries' | 'expertMode'>;
+type IslandBerries = Pick<TeamSettings['island'], 'berries' | 'expertMode'>;
 
 export class StrengthCalculator {
   public calculateStrength(params: {
-    settings: TeamSettingsExt;
+    settings: TeamSettings;
     produceWithoutSkill: MemberProduction['produceWithoutSkill'];
     produceFromSkill: MemberProduction['produceFromSkill'];
     skillValue: MemberProduction['skillValue'];

--- a/backend/src/services/simulation-service/team-simulator/team-simulator-benchmark.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator-benchmark.test.ts
@@ -5,9 +5,9 @@ import type {
   CalculateTeamResponse,
   Pokemon,
   PokemonWithIngredients,
-  TeamMemberExt,
-  TeamMemberSettingsExt,
-  TeamSettingsExt
+  TeamMember,
+  TeamMemberSettings,
+  TeamSettings
 } from 'sleepapi-common';
 import {
   ALL_BERRY_SPECIALISTS,
@@ -50,7 +50,7 @@ function randomPokemonWithIngredients(options: Pokemon[]): PokemonWithIngredient
   };
 }
 
-function randomTeamMemberSettings(pokemon: Pokemon): TeamMemberSettingsExt {
+function randomTeamMemberSettings(pokemon: Pokemon): TeamMemberSettings {
   return {
     level: (rng.getUint8() % 100) + 1,
     nature: rng.randomElement(nature.NATURES),
@@ -69,7 +69,7 @@ function randomTeamMemberSettings(pokemon: Pokemon): TeamMemberSettingsExt {
   };
 }
 
-function randomTeamMember(options: Pokemon[]): TeamMemberExt {
+function randomTeamMember(options: Pokemon[]): TeamMember {
   const pokemonWithIngredients = randomPokemonWithIngredients(options);
   const settings = randomTeamMemberSettings(pokemonWithIngredients.pokemon);
   return {
@@ -78,7 +78,7 @@ function randomTeamMember(options: Pokemon[]): TeamMemberExt {
   };
 }
 
-function randomTeam(): TeamMemberExt[] {
+function randomTeam(): TeamMember[] {
   return [
     randomTeamMember(primaryPokemon),
     randomTeamMember(primaryPokemon),
@@ -91,7 +91,7 @@ function randomTeam(): TeamMemberExt[] {
 // 5110 days is 14 years or 730 weeks
 const simulationDays = 5110;
 
-const mockSettings: TeamSettingsExt = mocks.teamSettingsExt({ includeCooking: true });
+const mockSettings: TeamSettings = mocks.teamSettings({ includeCooking: true });
 
 describe.runIf(isBenchmarking)('TeamSimulatorBenchmark', () => {
   it(

--- a/backend/src/services/simulation-service/team-simulator/team-simulator-utils.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator-utils.test.ts
@@ -1,6 +1,6 @@
 import { TeamSimulatorUtils } from '@src/services/simulation-service/team-simulator/team-simulator-utils.js';
 import { mocks } from '@src/vitest/index.js';
-import type { PokemonWithIngredients, TeamMemberExt, TeamMemberSettingsExt } from 'sleepapi-common';
+import type { PokemonWithIngredients, TeamMember, TeamMemberSettings } from 'sleepapi-common';
 import { berry, commonMocks, GREENGRASS_EXPERT, ingredient, nature, Optimal } from 'sleepapi-common';
 import { describe, expect, it } from 'vitest';
 
@@ -8,7 +8,7 @@ describe('calculateSkillPercentage', () => {
   const mockPokemonSet: PokemonWithIngredients = mocks.pokemonWithIngredients({
     pokemon: commonMocks.mockPokemon({ frequency: 3600, ingredientPercentage: 20, skillPercentage: 2 })
   });
-  const member: TeamMemberExt = mocks.teamMemberExt({ pokemonWithIngredients: mockPokemonSet });
+  const member: TeamMember = mocks.teamMember({ pokemonWithIngredients: mockPokemonSet });
 
   it('shall calculate skill percentage for member', () => {
     expect(
@@ -21,7 +21,7 @@ describe('calculateIngredientPercentage', () => {
   const mockPokemonSet: PokemonWithIngredients = mocks.pokemonWithIngredients({
     pokemon: commonMocks.mockPokemon({ frequency: 3600, ingredientPercentage: 20, skillPercentage: 2 })
   });
-  const member: TeamMemberExt = mocks.teamMemberExt({ pokemonWithIngredients: mockPokemonSet });
+  const member: TeamMember = mocks.teamMember({ pokemonWithIngredients: mockPokemonSet });
 
   it('shall calculate ingredient percentage for member', () => {
     expect(
@@ -37,14 +37,14 @@ describe('calculateHelpSpeedBeforeEnergy', () => {
   const mockPokemonSet: PokemonWithIngredients = mocks.pokemonWithIngredients({
     pokemon: commonMocks.mockPokemon({ frequency: 3600, ingredientPercentage: 20, skillPercentage: 2 })
   });
-  const member: TeamMemberExt = mocks.teamMemberExt({ pokemonWithIngredients: mockPokemonSet });
+  const member: TeamMember = mocks.teamMember({ pokemonWithIngredients: mockPokemonSet });
 
   it('should calculate help speed without energy applied', () => {
     expect(
       TeamSimulatorUtils.calculateHelpSpeedBeforeEnergy({
         member: { ...member, settings: { ...member.settings, nature: nature.LONELY, level: 1 } },
         teamHelpingBonus: 0,
-        settings: mocks.teamSettingsExt()
+        settings: mocks.teamSettings()
       })
     ).toBe(3240);
   });
@@ -72,11 +72,11 @@ describe('calculateAverageProduce', () => {
         commonMocks.mockIngredientSet({ amount: 7, ingredient: ingredient.WARMING_GINGER })
       ]
     });
-    const member: TeamMemberExt = mocks.teamMemberExt({ pokemonWithIngredients: mockTyranitar });
+    const member: TeamMember = mocks.teamMember({ pokemonWithIngredients: mockTyranitar });
 
     it('should calculate average level 29 produce', () => {
       const optimalSettings = Optimal.ingredient(member.pokemonWithIngredients.pokemon);
-      const settings: TeamMemberSettingsExt = {
+      const settings: TeamMemberSettings = {
         carrySize: 0,
         ribbon: 0,
         skillLevel: 0,
@@ -97,7 +97,7 @@ describe('calculateAverageProduce', () => {
 
     it('should calculate average level 30 produce', () => {
       const optimalSettings = Optimal.ingredient(member.pokemonWithIngredients.pokemon);
-      const settings: TeamMemberSettingsExt = {
+      const settings: TeamMemberSettings = {
         carrySize: 0,
         ribbon: 0,
         skillLevel: 0,
@@ -118,7 +118,7 @@ describe('calculateAverageProduce', () => {
 
     it('should calculate average level 60 produce', () => {
       const optimalSettings = Optimal.ingredient(member.pokemonWithIngredients.pokemon);
-      const settings: TeamMemberSettingsExt = {
+      const settings: TeamMemberSettings = {
         carrySize: 0,
         ribbon: 0,
         skillLevel: 0,
@@ -139,7 +139,7 @@ describe('calculateAverageProduce', () => {
 
     it('should calculate average level 75 produce', () => {
       const optimalSettings = Optimal.ingredient(member.pokemonWithIngredients.pokemon);
-      const settings: TeamMemberSettingsExt = {
+      const settings: TeamMemberSettings = {
         carrySize: 0,
         ribbon: 0,
         skillLevel: 0,
@@ -157,7 +157,7 @@ describe('calculateAverageProduce', () => {
 
     it('should calculate average level 100 produce', () => {
       const optimalSettings = Optimal.ingredient(member.pokemonWithIngredients.pokemon);
-      const settings: TeamMemberSettingsExt = {
+      const settings: TeamMemberSettings = {
         carrySize: 0,
         ribbon: 0,
         skillLevel: 0,
@@ -180,7 +180,7 @@ describe('calculateAverageProduce', () => {
 
 describe('prepareMembers', () => {
   const createMember = () =>
-    mocks.teamMemberExt({
+    mocks.teamMember({
       pokemonWithIngredients: mocks.pokemonWithIngredients({
         pokemon: commonMocks.mockPokemon({
           berry: berry.ORAN,
@@ -188,7 +188,7 @@ describe('prepareMembers', () => {
           skillPercentage: 0.2
         })
       }),
-      settings: mocks.teamMemberSettingsExt({ skillLevel: 3 })
+      settings: mocks.teamMemberSettings({ skillLevel: 3 })
     });
 
   it('returns members untouched when no event present', () => {
@@ -219,7 +219,7 @@ describe('prepareMembers', () => {
   });
 
   it('applies no frequency change for sub berry pokemon', () => {
-    const subBerryMember = mocks.teamMemberExt({
+    const subBerryMember = mocks.teamMember({
       pokemonWithIngredients: mocks.pokemonWithIngredients({
         pokemon: commonMocks.mockPokemon({
           berry: berry.MAGO,
@@ -227,7 +227,7 @@ describe('prepareMembers', () => {
           skillPercentage: 0.2
         })
       }),
-      settings: mocks.teamMemberSettingsExt({ skillLevel: 3 })
+      settings: mocks.teamMemberSettings({ skillLevel: 3 })
     });
 
     const event = GREENGRASS_EXPERT.bonuses({
@@ -247,7 +247,7 @@ describe('prepareMembers', () => {
   });
 
   it('applies 15% frequency nerf for non-favored pokemon', () => {
-    const unfavoredMember = mocks.teamMemberExt({
+    const unfavoredMember = mocks.teamMember({
       pokemonWithIngredients: mocks.pokemonWithIngredients({
         pokemon: commonMocks.mockPokemon({
           berry: berry.BELUE,
@@ -255,7 +255,7 @@ describe('prepareMembers', () => {
           skillPercentage: 0.2
         })
       }),
-      settings: mocks.teamMemberSettingsExt({ skillLevel: 3 })
+      settings: mocks.teamMemberSettings({ skillLevel: 3 })
     });
 
     const event = GREENGRASS_EXPERT.bonuses({
@@ -295,17 +295,17 @@ describe('countMembersWithSubskill', () => {
   const mockPokemonSet: PokemonWithIngredients = mocks.pokemonWithIngredients({
     pokemon: commonMocks.mockPokemon({ frequency: 3600, ingredientPercentage: 20, skillPercentage: 2 })
   });
-  const member1: TeamMemberExt = mocks.teamMemberExt({
+  const member1: TeamMember = mocks.teamMember({
     pokemonWithIngredients: mockPokemonSet,
-    settings: mocks.teamMemberSettingsExt({ subskills: new Set(['subskill1', 'subskill2']) })
+    settings: mocks.teamMemberSettings({ subskills: new Set(['subskill1', 'subskill2']) })
   });
-  const member2: TeamMemberExt = mocks.teamMemberExt({
+  const member2: TeamMember = mocks.teamMember({
     pokemonWithIngredients: mockPokemonSet,
-    settings: mocks.teamMemberSettingsExt({ subskills: new Set(['subskill2', 'subskill3']) })
+    settings: mocks.teamMemberSettings({ subskills: new Set(['subskill2', 'subskill3']) })
   });
-  const member3: TeamMemberExt = mocks.teamMemberExt({
+  const member3: TeamMember = mocks.teamMember({
     pokemonWithIngredients: mockPokemonSet,
-    settings: mocks.teamMemberSettingsExt({ subskills: new Set(['subskill1', 'subskill3']) })
+    settings: mocks.teamMemberSettings({ subskills: new Set(['subskill1', 'subskill3']) })
   });
 
   it('should count members with a specific subskill', () => {

--- a/backend/src/services/simulation-service/team-simulator/team-simulator-utils.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator-utils.ts
@@ -2,7 +2,7 @@ import { calculateHelpSpeedBeforeEnergy } from '@src/services/calculator/help/he
 import type { CookingState } from '@src/services/simulation-service/team-simulator/cooking-state/cooking-state.js';
 import { getDefaultMealTimes } from '@src/utils/meal-utils/meal-utils.js';
 import { TimeUtils } from '@src/utils/time-utils/time-utils.js';
-import type { FunctionalEvent, ProduceFlat, TeamMemberExt, TeamSettingsExt, TimePeriod } from 'sleepapi-common';
+import type { FunctionalEvent, ProduceFlat, TeamMember, TeamSettings, TimePeriod } from 'sleepapi-common';
 import {
   berrySetToFlat,
   calculateAveragePokemonIngredientSet,
@@ -12,7 +12,7 @@ import {
 } from 'sleepapi-common';
 
 class TeamSimulatorUtilsImpl {
-  public setupSimulationTimes(params: { settings: TeamSettingsExt; cookingState?: CookingState }): {
+  public setupSimulationTimes(params: { settings: TeamSettings; cookingState?: CookingState }): {
     nightStartMinutes: number;
     mealTimeMinutesSinceStart: number[];
   } {
@@ -37,7 +37,7 @@ class TeamSimulatorUtilsImpl {
     };
   }
 
-  public prepareMembers(params: { members: TeamMemberExt[]; event?: FunctionalEvent }): TeamMemberExt[] {
+  public prepareMembers(params: { members: TeamMember[]; event?: FunctionalEvent }): TeamMember[] {
     const { members, event } = params;
 
     if (!event) {
@@ -47,7 +47,7 @@ class TeamSimulatorUtilsImpl {
     return members.map((member) => event.applyToTeam(member));
   }
 
-  public calculateSkillPercentage(member: TeamMemberExt) {
+  public calculateSkillPercentage(member: TeamMember) {
     return calculateSkillPercentage(
       member.pokemonWithIngredients.pokemon.skillPercentage,
       member.settings.subskills,
@@ -55,7 +55,7 @@ class TeamSimulatorUtilsImpl {
     );
   }
 
-  public calculateIngredientPercentage(member: TeamMemberExt) {
+  public calculateIngredientPercentage(member: TeamMember) {
     return calculateIngredientPercentage({
       pokemon: member.pokemonWithIngredients.pokemon,
       nature: member.settings.nature,
@@ -63,7 +63,7 @@ class TeamSimulatorUtilsImpl {
     });
   }
 
-  public calculateAverageProduce(member: TeamMemberExt): ProduceFlat {
+  public calculateAverageProduce(member: TeamMember): ProduceFlat {
     const ingredientPercentage = TeamSimulatorUtils.calculateIngredientPercentage(member);
 
     const avgIngredientList = calculateAveragePokemonIngredientSet(
@@ -86,8 +86,8 @@ class TeamSimulatorUtilsImpl {
   }
 
   public calculateHelpSpeedBeforeEnergy(params: {
-    member: TeamMemberExt;
-    settings: TeamSettingsExt;
+    member: TeamMember;
+    settings: TeamSettings;
     teamHelpingBonus: number;
   }) {
     const { member, settings, teamHelpingBonus } = params;
@@ -103,7 +103,7 @@ class TeamSimulatorUtilsImpl {
     });
   }
 
-  public countMembersWithSubskill(team: TeamMemberExt[], subskill: string): number {
+  public countMembersWithSubskill(team: TeamMember[], subskill: string): number {
     let count = 0;
     for (const member of team) {
       if (member.settings.subskills.has(subskill)) {

--- a/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator.test.ts
@@ -6,7 +6,7 @@ import type {
 } from '@src/services/simulation-service/team-simulator/skill-state/skill-state-types.js';
 import { TeamSimulator } from '@src/services/simulation-service/team-simulator/team-simulator.js';
 import { mocks } from '@src/vitest/index.js';
-import type { Berry, PokemonSpecialty, PokemonWithIngredients, TeamMemberExt, TeamSettingsExt } from 'sleepapi-common';
+import type { Berry, PokemonSpecialty, PokemonWithIngredients, TeamMember, TeamSettings } from 'sleepapi-common';
 import {
   BASE_FAVORED_BERRY_MULTIPLIER,
   BerryBurstDisguise,
@@ -45,8 +45,8 @@ const mockPokemonWithIngredients: PokemonWithIngredients = {
     { amount: 1, ingredient: ingredient.SLOWPOKE_TAIL }
   ]
 };
-const mockSettings: TeamSettingsExt = mocks.teamSettingsExt({ includeCooking: true });
-const mockMembers: TeamMemberExt[] = [
+const mockSettings: TeamSettings = mocks.teamSettings({ includeCooking: true });
+const mockMembers: TeamMember[] = [
   {
     pokemonWithIngredients: mockPokemonWithIngredients,
     settings: {
@@ -90,12 +90,12 @@ describe('TeamSimulator', () => {
   });
 
   it('shall calculate production with uneven sleep times', () => {
-    const settings: TeamSettingsExt = mocks.teamSettingsExt({
+    const settings: TeamSettings = mocks.teamSettings({
       includeCooking: true,
       wakeup: parseTime('06:01')
     });
 
-    const members: TeamMemberExt[] = [
+    const members: TeamMember[] = [
       {
         pokemonWithIngredients: {
           pokemon: PINSIR,
@@ -129,7 +129,7 @@ describe('TeamSimulator', () => {
   });
 
   it('shall calculate team with multiple members', () => {
-    const mockMember: TeamMemberExt = {
+    const mockMember: TeamMember = {
       pokemonWithIngredients: mockPokemonWithIngredients,
       settings: {
         carrySize: 10,
@@ -143,7 +143,7 @@ describe('TeamSimulator', () => {
       }
     };
 
-    const members: TeamMemberExt[] = [mockMember, mockMember, mockMember, mockMember, mockMember];
+    const members: TeamMember[] = [mockMember, mockMember, mockMember, mockMember, mockMember];
     const simulator = new TeamSimulator({ settings: mockSettings, members, iterations: 1 });
 
     simulator.simulate();
@@ -174,7 +174,7 @@ describe('TeamSimulator', () => {
   });
 
   it('team members shall affect each other', () => {
-    const mockMember: TeamMemberExt = {
+    const mockMember: TeamMember = {
       pokemonWithIngredients: mockPokemonWithIngredients,
       settings: {
         carrySize: 10,
@@ -192,7 +192,7 @@ describe('TeamSimulator', () => {
       skillPercentage: 100,
       skill: EnergyForEveryoneS
     };
-    const mockMemberSupport: TeamMemberExt = {
+    const mockMemberSupport: TeamMember = {
       pokemonWithIngredients: {
         ...mockPokemonWithIngredients,
         pokemon: mockMemberSupportPokemon
@@ -209,7 +209,7 @@ describe('TeamSimulator', () => {
       }
     };
 
-    const members: TeamMemberExt[] = [mockMember, mockMemberSupport];
+    const members: TeamMember[] = [mockMember, mockMemberSupport];
     const simulator = new TeamSimulator({ settings: mockSettings, members, iterations: 1 });
 
     simulator.simulate();
@@ -229,7 +229,7 @@ describe('TeamSimulator', () => {
       skillPercentage: 100,
       skill: EnergyForEveryoneS
     };
-    const mockMemberSupport: TeamMemberExt = {
+    const mockMemberSupport: TeamMember = {
       pokemonWithIngredients: {
         ...mockPokemonWithIngredients,
         pokemon: mockMemberSupportPokemon
@@ -246,7 +246,7 @@ describe('TeamSimulator', () => {
       }
     };
 
-    const members: TeamMemberExt[] = [
+    const members: TeamMember[] = [
       mockMemberSupport,
       mockMemberSupport,
       mockMemberSupport,
@@ -281,7 +281,7 @@ describe('TeamSimulator', () => {
         pityProcThreshold: calculatePityProcThreshold('skill', 3000)
       }
     };
-    const members: TeamMemberExt[] = [
+    const members: TeamMember[] = [
       {
         pokemonWithIngredients: mockMember,
         settings: {
@@ -326,7 +326,7 @@ describe('TeamSimulator', () => {
       // 100% chance to activate skill per help
       skillPercentage: 100
     };
-    const members: TeamMemberExt[] = [
+    const members: TeamMember[] = [
       {
         pokemonWithIngredients: {
           ...mockPokemonWithIngredients,
@@ -361,7 +361,7 @@ describe('TeamSimulator', () => {
   });
 
   describe('expert mode event modifiers', () => {
-    const settings: TeamSettingsExt = mocks.teamSettingsExt({
+    const settings: TeamSettings = mocks.teamSettings({
       includeCooking: false,
       island: commonMocks.islandInstance({
         expert: true,
@@ -374,7 +374,7 @@ describe('TeamSimulator', () => {
       })
     });
 
-    const buildMember = (memberBerry: Berry): TeamMemberExt => {
+    const buildMember = (memberBerry: Berry): TeamMember => {
       const pokemon = commonMocks.mockPokemon({
         berry: memberBerry,
         frequency: 1800,
@@ -434,8 +434,8 @@ describe('TeamSimulator', () => {
     const buildExpertModeSettings = (params: {
       randomBonus: 'berry' | 'ingredient' | 'skill';
       areaBonus?: number;
-    }): TeamSettingsExt =>
-      mocks.teamSettingsExt({
+    }): TeamSettings =>
+      mocks.teamSettings({
         includeCooking: false,
         island: commonMocks.islandInstance({
           expert: true,
@@ -453,7 +453,7 @@ describe('TeamSimulator', () => {
       carrySize: number;
       specialty: PokemonSpecialty;
       externalId: string;
-    }): TeamMemberExt => {
+    }): TeamMember => {
       const pokemon = commonMocks.mockPokemon({
         carrySize: params.carrySize,
         frequency: 3600,

--- a/backend/src/services/simulation-service/team-simulator/team-simulator.ts
+++ b/backend/src/services/simulation-service/team-simulator/team-simulator.ts
@@ -31,8 +31,8 @@ import {
   type FunctionalEvent,
   type MemberProductionBase,
   type SimpleTeamResult,
-  type TeamMemberExt,
-  type TeamSettingsExt
+  type TeamMember,
+  type TeamSettings
 } from 'sleepapi-common';
 
 export class TeamSimulator {
@@ -51,8 +51,8 @@ export class TeamSimulator {
   private energyDegradeCounter = -1; // -1 so it takes 3 iterations and first degrade is after 10 minutes, then 10 minutes between each
 
   constructor(params: {
-    settings: TeamSettingsExt;
-    members: TeamMemberExt[];
+    settings: TeamSettings;
+    members: TeamMember[];
     cookingState?: CookingState;
     iterations: number;
     rng?: PreGeneratedRandom;

--- a/backend/src/services/solve/solve-service.test.ts
+++ b/backend/src/services/solve/solve-service.test.ts
@@ -14,7 +14,7 @@ describe('SolveService', () => {
     const recipe: Recipe = commonMocks.mockRecipe({
       ingredients: ingredientList
     });
-    const member = mocks.teamMemberExt({
+    const member = mocks.teamMember({
       pokemonWithIngredients: mocks.pokemonWithIngredients({
         ingredientList,
         pokemon: commonMocks.mockPokemon({ skill: BerryBurst })
@@ -27,7 +27,7 @@ describe('SolveService', () => {
     }));
 
     const input: SolveRecipeInput = {
-      solveSettings: mocks.solveSettingsExt(),
+      solveSettings: mocks.solveSettings(),
       includedMembers: [member],
       maxTeamSize: 5
     };

--- a/backend/src/services/solve/solve-service.ts
+++ b/backend/src/services/solve/solve-service.ts
@@ -9,7 +9,7 @@ import {
   groupProducersByIngredient,
   pokemonProductionToRecipeSolutions
 } from '@src/services/solve/utils/solve-utils.js';
-import type { Ingredient, Recipe, SolveSettingsExt } from 'sleepapi-common';
+import type { Ingredient, Recipe, SolveSettings } from 'sleepapi-common';
 import { ingredientSetToIntFlat } from 'sleepapi-common';
 
 class SolveServiceImpl {
@@ -55,7 +55,7 @@ class SolveServiceImpl {
 
   // TODO: Implement for new site
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public solveIngredient(ingredient: Ingredient, settings: SolveSettingsExt) {
+  public solveIngredient(ingredient: Ingredient, settings: SolveSettings) {
     //
   }
 }

--- a/backend/src/services/solve/types/solution-types.ts
+++ b/backend/src/services/solve/types/solution-types.ts
@@ -1,9 +1,9 @@
 import type { IngredientProducersWithSettings } from '@src/services/solve/types/set-cover-pokemon-setup-types.js';
-import type { IngredientIndexToIntAmount, SolveSettingsExt, TeamMemberExt } from 'sleepapi-common';
+import type { IngredientIndexToIntAmount, SolveSettings, TeamMember } from 'sleepapi-common';
 
 export interface SolveRecipeInput {
-  includedMembers: TeamMemberExt[];
-  solveSettings: SolveSettingsExt;
+  includedMembers: TeamMember[];
+  solveSettings: SolveSettings;
   maxTeamSize: number;
 }
 

--- a/backend/src/services/solve/utils/solve-utils.test.ts
+++ b/backend/src/services/solve/utils/solve-utils.test.ts
@@ -19,8 +19,7 @@ import {
   settingsToArraySubskills
 } from '@src/services/solve/utils/solve-utils.js';
 import { mocks } from '@src/vitest/index.js';
-import type { IngredientSet, Pokedex, SolveSettingsExt } from 'sleepapi-common';
-import { splitArrayByCondition } from 'sleepapi-common';
+import type { IngredientSet, Pokedex, SolveSettings } from 'sleepapi-common';
 import {
   CookingPowerUpS,
   ENTEI,
@@ -33,7 +32,8 @@ import {
   flatToIngredientSet,
   ingredient,
   ingredientSetToIntFlat,
-  prettifyIngredientDrop
+  prettifyIngredientDrop,
+  splitArrayByCondition
 } from 'sleepapi-common';
 import { vimic } from 'vimic';
 import type { MockInstance } from 'vitest';
@@ -46,10 +46,8 @@ describe('solve-utils', () => {
   // TEST: this function is tested too little, function is probably also too big
   describe('calculateProductionAll', () => {
     it('should calculate all pokemon, including user pokemon', () => {
-      const userIncludedMembers = [
-        mocks.teamMemberExt({ settings: mocks.teamMemberSettingsExt({ externalId: 'user1' }) })
-      ];
-      const settings: SolveSettingsExt = { ...mocks.teamSettingsExt(), level: 60 };
+      const userIncludedMembers = [mocks.teamMember({ settings: mocks.teamMemberSettings({ externalId: 'user1' }) })];
+      const settings: SolveSettings = { ...mocks.teamSettings(), level: 60 };
 
       const teamSpy = vimic(productionService, 'calculateTeam', () =>
         mocks.teamResults({
@@ -57,7 +55,7 @@ describe('solve-utils', () => {
         })
       );
       const simpleSpy = vimic(productionService, 'calculateSimple', () => [
-        mocks.simpleTeamResult({ member: mocks.teamMemberExt() })
+        mocks.simpleTeamResult({ member: mocks.teamMember() })
       ]);
 
       const result = calculateProductionAll({
@@ -81,7 +79,7 @@ describe('solve-utils', () => {
 
   describe('filterPokedex', () => {
     it('should return COMPLETE_POKEDEX if input array has no helper boost Pokémon', () => {
-      expect(filterPokedex([mocks.teamMemberExt()])).toEqual(OPTIMAL_POKEDEX);
+      expect(filterPokedex([mocks.teamMember()])).toEqual(OPTIMAL_POKEDEX);
     });
 
     it('should return COMPLETE_POKEDEX if input array is empty', () => {
@@ -90,8 +88,8 @@ describe('solve-utils', () => {
 
     it('should remove helper boost pokemon in input array from COMPLETE_POKEDEX', () => {
       const filteredPokedex = filterPokedex([
-        mocks.teamMemberExt({ pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: SUICUNE }) }),
-        mocks.teamMemberExt({ pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: RAIKOU }) })
+        mocks.teamMember({ pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: SUICUNE }) }),
+        mocks.teamMember({ pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon: RAIKOU }) })
       ]);
 
       expect(filteredPokedex).toContain(ENTEI);
@@ -170,11 +168,11 @@ Set {
 
   describe('calculateSupportPokemon', () => {
     it('should calculate production one by one for each support member', () => {
-      const supportPokemon1 = mocks.teamMemberExt({
-        settings: mocks.teamMemberSettingsExt({ externalId: 'supportPokemon1' })
+      const supportPokemon1 = mocks.teamMember({
+        settings: mocks.teamMemberSettings({ externalId: 'supportPokemon1' })
       });
-      const supportPokemon2 = mocks.teamMemberExt({
-        settings: mocks.teamMemberSettingsExt({ externalId: 'supportPokemon2' })
+      const supportPokemon2 = mocks.teamMember({
+        settings: mocks.teamMemberSettings({ externalId: 'supportPokemon2' })
       });
 
       const simpleCalcSpy = vimic(
@@ -187,7 +185,7 @@ Set {
       const result = calculateSupportPokemon({
         supportMembers: [supportPokemon1, supportPokemon2],
         userMembers: [],
-        settings: mocks.teamSettingsExt(),
+        settings: mocks.teamSettings(),
         userRecipes: defaultUserRecipes()
       });
       expect(result).toHaveLength(2);
@@ -198,8 +196,8 @@ Set {
     });
 
     it('should not return supportMembers not returned by simulator', () => {
-      const supportPokemon1 = mocks.teamMemberExt({
-        settings: mocks.teamMemberSettingsExt({ externalId: 'supportPokemon1' })
+      const supportPokemon1 = mocks.teamMember({
+        settings: mocks.teamMemberSettings({ externalId: 'supportPokemon1' })
       });
 
       const simpleCalcSpy = vimic(productionService, 'calculateSimple', () => []);
@@ -207,7 +205,7 @@ Set {
       const result = calculateSupportPokemon({
         supportMembers: [supportPokemon1],
         userMembers: [],
-        settings: mocks.teamSettingsExt(),
+        settings: mocks.teamSettings(),
         userRecipes: defaultUserRecipes()
       });
       expect(result).toHaveLength(0);
@@ -215,17 +213,17 @@ Set {
     });
 
     it("should include user's members in every simulation", () => {
-      const userPokemon1 = mocks.teamMemberExt({
-        settings: mocks.teamMemberSettingsExt({ externalId: 'userPokemon1' })
+      const userPokemon1 = mocks.teamMember({
+        settings: mocks.teamMemberSettings({ externalId: 'userPokemon1' })
       });
-      const userPokemon2 = mocks.teamMemberExt({
-        settings: mocks.teamMemberSettingsExt({ externalId: 'userPokemon2' })
+      const userPokemon2 = mocks.teamMember({
+        settings: mocks.teamMemberSettings({ externalId: 'userPokemon2' })
       });
-      const supportPokemon1 = mocks.teamMemberExt({
-        settings: mocks.teamMemberSettingsExt({ externalId: 'supportPokemon1' })
+      const supportPokemon1 = mocks.teamMember({
+        settings: mocks.teamMemberSettings({ externalId: 'supportPokemon1' })
       });
-      const supportPokemon2 = mocks.teamMemberExt({
-        settings: mocks.teamMemberSettingsExt({ externalId: 'supportPokemon2' })
+      const supportPokemon2 = mocks.teamMember({
+        settings: mocks.teamMemberSettings({ externalId: 'supportPokemon2' })
       });
 
       const simpleCalcSpy: MockInstance = vimic(
@@ -238,7 +236,7 @@ Set {
       const result = calculateSupportPokemon({
         supportMembers: [supportPokemon1, supportPokemon2],
         userMembers: [userPokemon1, userPokemon2],
-        settings: mocks.teamSettingsExt(),
+        settings: mocks.teamSettings(),
         userRecipes: defaultUserRecipes()
       });
       expect(result).toHaveLength(2);
@@ -266,8 +264,8 @@ Set {
     });
 
     it('should include a bogus member for each empty space in the simulator', () => {
-      const supportPokemon1 = mocks.teamMemberExt({
-        settings: mocks.teamMemberSettingsExt({ externalId: 'supportPokemon1' })
+      const supportPokemon1 = mocks.teamMember({
+        settings: mocks.teamMemberSettings({ externalId: 'supportPokemon1' })
       });
 
       const simpleSpy = vimic(productionService, 'calculateSimple', () => [
@@ -277,13 +275,13 @@ Set {
       const result = calculateSupportPokemon({
         supportMembers: [supportPokemon1],
         userMembers: [],
-        settings: mocks.teamSettingsExt(),
+        settings: mocks.teamSettings(),
         userRecipes: defaultUserRecipes()
       });
       expect(result).toHaveLength(1);
       expect(result[0].member.settings.externalId).toEqual(supportPokemon1.settings.externalId);
 
-      const bogusMember = mocks.teamMemberExt();
+      const bogusMember = mocks.teamMember();
 
       expect(simpleSpy).toHaveBeenCalledTimes(1);
       expect(simpleSpy.mock.calls[0][0]).toEqual(
@@ -322,9 +320,9 @@ Set {
         ingredient30: [ingredientListA],
         ingredient60: [ingredientListA, ingredientListB]
       });
-      const member = mocks.teamMemberExt({
+      const member = mocks.teamMember({
         pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon }),
-        settings: mocks.teamMemberSettingsExt({ level: 60 })
+        settings: mocks.teamMemberSettings({ level: 60 })
       });
       const simpleResults = mocks.simpleTeamResult({ member });
 
@@ -357,9 +355,9 @@ Set {
         ingredient60: [ingredientListA],
         ingredientPercentage: 100
       });
-      const member = mocks.teamMemberExt({
+      const member = mocks.teamMember({
         pokemonWithIngredients: mocks.pokemonWithIngredients({ pokemon }),
-        settings: mocks.teamMemberSettingsExt({ level: 60 })
+        settings: mocks.teamMemberSettings({ level: 60 })
       });
       const simpleResults = mocks.simpleTeamResult({ member, totalHelps: 10 });
 
@@ -598,9 +596,9 @@ Set {
 
   describe('calculateNonSupportPokemon', () => {
     it('should calculate non-support pokemon production without cooking', () => {
-      const nonSupportMembers = [mocks.teamMemberExt()];
-      const userMembers = [mocks.teamMemberExt()];
-      const settings = mocks.teamSettingsExt({ includeCooking: true });
+      const nonSupportMembers = [mocks.teamMember()];
+      const userMembers = [mocks.teamMember()];
+      const settings = mocks.teamSettings({ includeCooking: true });
 
       const simpleSpy = vimic(productionService, 'calculateSimple', () => [
         mocks.simpleTeamResult({ member: nonSupportMembers[0] })
@@ -620,19 +618,19 @@ Set {
 
     it('should calculate non-support pokemon production with cooking', () => {
       const nonSupportMembers = [
-        mocks.teamMemberExt({
+        mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: commonMocks.mockPokemon({ skill: TastyChanceS })
           })
         }),
-        mocks.teamMemberExt({
+        mocks.teamMember({
           pokemonWithIngredients: mocks.pokemonWithIngredients({
             pokemon: commonMocks.mockPokemon({ skill: CookingPowerUpS })
           })
         })
       ];
-      const userMembers = [mocks.teamMemberExt()];
-      const settings = mocks.teamSettingsExt({ includeCooking: true });
+      const userMembers = [mocks.teamMember()];
+      const settings = mocks.teamSettings({ includeCooking: true });
 
       const simpleSpy = vimic(
         productionService,
@@ -658,7 +656,7 @@ Set {
 
   describe('settingsToArraySubskills', () => {
     it('should convert subskills set to array', () => {
-      const settings = mocks.teamMemberSettingsExt();
+      const settings = mocks.teamMemberSettings();
       const result = settingsToArraySubskills(settings);
       expect(result.subskills).toBeInstanceOf(Array);
     });

--- a/backend/src/services/solve/utils/solve-utils.ts
+++ b/backend/src/services/solve/utils/solve-utils.ts
@@ -22,11 +22,11 @@ import type {
   PokemonWithIngredients,
   PokemonWithIngredientsIndexed,
   SimpleTeamResult,
-  SolveSettingsExt,
-  TeamMemberExt,
-  TeamMemberSettingsExt,
+  SolveSettings,
+  TeamMember,
+  TeamMemberSettings,
   TeamMemberSettingsResult,
-  TeamSettingsExt
+  TeamSettings
 } from 'sleepapi-common';
 import {
   CarrySizeUtils,
@@ -52,8 +52,8 @@ import {
 } from 'sleepapi-common';
 
 export function calculateProductionAll(params: {
-  settings: SolveSettingsExt;
-  userMembers: TeamMemberExt[];
+  settings: SolveSettings;
+  userMembers: TeamMember[];
   userRecipes: UserRecipes;
 }): {
   userProduction: SetCoverPokemonSetupWithSettings[];
@@ -135,7 +135,7 @@ export function calculateProductionAll(params: {
   return { userProduction, nonSupportProduction, supportProduction };
 }
 
-export function settingsToArraySubskills(settings: TeamMemberSettingsExt): TeamMemberSettingsResult {
+export function settingsToArraySubskills(settings: TeamMemberSettings): TeamMemberSettingsResult {
   return { ...settings, subskills: [...settings.subskills] };
 }
 
@@ -143,7 +143,7 @@ export function settingsToArraySubskills(settings: TeamMemberSettingsExt): TeamM
  * Filters Pokédex to return relevant Pokémon for the solve.
  * Currently only make sure we remove any legendaries (helper boost) if the included user Pokémon already have them
  */
-export function filterPokedex(members: TeamMemberExt[]) {
+export function filterPokedex(members: TeamMember[]) {
   const helperBoostIncludedMembers = new Set(
     members
       .filter((member) => member.pokemonWithIngredients.pokemon.skill.is(HelperBoost))
@@ -155,9 +155,9 @@ export function filterPokedex(members: TeamMemberExt[]) {
 }
 
 /**
- * Converts a Pokedex into an array of `TeamMemberExt` objects with optimal settings and ingredients.
+ * Converts a Pokedex into an array of `TeamMember` objects with optimal settings and ingredients.
  *
- * This function processes each Pokémon in the Pokedex to create a corresponding `TeamMemberExt` object.
+ * This function processes each Pokémon in the Pokedex to create a corresponding `TeamMember` object.
  * For each Pokémon, an `AAA` ingredient list is generated, and either ingredient-focused or skill-focused
  * settings are applied based on specific criteria.
  *
@@ -165,21 +165,21 @@ export function filterPokedex(members: TeamMemberExt[]) {
  * @param {boolean} params.support - Determines if support-focused settings should be applied.
  *        When `true`, skill-focused settings are prioritized for Pokémon with a supporting skill.
  * @param {number} params.level - The level to assign to all team members.
- * @returns {TeamMemberExt[]} An array of `TeamMemberExt` objects, where each object represents:
+ * @returns {TeamMember[]} An array of `TeamMember` objects, where each object represents:
  *        - Optimal settings for the Pokémon, based on its type and role.
  *        - A derived `AAA` ingredient list containing ingredients for different skill thresholds.
  *
  * ### Behavior:
- * - Generates one `TeamMemberExt` per Pokémon in the Pokedex.
+ * - Generates one `TeamMember` per Pokémon in the Pokedex.
  * - Applies ingredient-focused subskills and nature by default.
  * - Conditionally uses skill-focused subskills when all of the following are true:
  *   1. `params.support` is `true`.
  *   2. The Pokémon is classified as a skill specialist.
  *   3. The Pokémon's skill belongs to the set of predefined supporting skills (e.g., "E4E", "Extra Helpful").
  */
-export function pokedexToMembers(params: { pokedex: Pokedex; level: number; camp: boolean }): TeamMemberExt[] {
+export function pokedexToMembers(params: { pokedex: Pokedex; level: number; camp: boolean }): TeamMember[] {
   const { pokedex, level, camp } = params;
-  const pokedexAsMembers: TeamMemberExt[] = [];
+  const pokedexAsMembers: TeamMember[] = [];
 
   const INGREDIENT_SUPPORT_MAINSKILLS_SET = new Set(INGREDIENT_SUPPORT_MAINSKILLS.map((ms) => ms.name));
   // TODO: there needs to be a better way to do this
@@ -225,9 +225,9 @@ export function pokedexToMembers(params: { pokedex: Pokedex; level: number; camp
 }
 
 export function calculateNonSupportPokemon(params: {
-  nonSupportMembers: TeamMemberExt[];
-  userMembers: TeamMemberExt[];
-  settings: TeamSettingsExt;
+  nonSupportMembers: TeamMember[];
+  userMembers: TeamMember[];
+  settings: TeamSettings;
   userRecipes: UserRecipes;
 }): SimpleTeamResult[] {
   const { nonSupportMembers, userMembers, settings, userRecipes } = params;
@@ -300,9 +300,9 @@ export function calculateNonSupportPokemon(params: {
 }
 
 export function calculateSupportPokemon(params: {
-  supportMembers: TeamMemberExt[];
-  userMembers: TeamMemberExt[];
-  settings: TeamSettingsExt;
+  supportMembers: TeamMember[];
+  userMembers: TeamMember[];
+  settings: TeamSettings;
   userRecipes: UserRecipes;
 }): SimpleTeamResult[] {
   const { supportMembers, userMembers, settings, userRecipes } = params;
@@ -336,7 +336,7 @@ export function convertAAAToAllIngredientSets(
     skillIngredients: IngredientIndexToFloatAmount;
     critMultiplier: number;
     averageWeekdayPotSize: number;
-    settings: TeamMemberSettingsExt;
+    settings: TeamMemberSettings;
   }[]
 ): SetCoverPokemonSetupWithSettings[] {
   const result: SetCoverPokemonSetupWithSettings[] = [];
@@ -346,7 +346,7 @@ export function convertAAAToAllIngredientSets(
     const skillIngredientsPerMealWindow = aaaResult.skillIngredients._mutateUnary((ing) => ing / MEALS_IN_DAY);
 
     for (const ingredientList of getAllIngredientLists(pokemon, aaaResult.settings.level)) {
-      const memberWithIngList: TeamMemberExt = {
+      const memberWithIngList: TeamMember = {
         pokemonWithIngredients: { pokemon, ingredientList },
         settings: aaaResult.settings
       };
@@ -428,8 +428,8 @@ export function combineProduction(members: SetCoverPokemonSetup[]) {
   );
 }
 
-export function bogusMembers(nrOfMembers: number): TeamMemberExt[] {
-  const bogusMember: TeamMemberExt = mocks.teamMemberExt();
+export function bogusMembers(nrOfMembers: number): TeamMember[] {
+  const bogusMember: TeamMember = mocks.teamMember();
   return new Array(nrOfMembers).fill(bogusMember);
 }
 

--- a/backend/src/services/tier-list/cooking-tier-list.test.ts
+++ b/backend/src/services/tier-list/cooking-tier-list.test.ts
@@ -1,4 +1,4 @@
-import { teamMemberSettings } from '@src/vitest/mocks/index.js';
+import { teamMemberSettingsDto } from '@src/vitest/mocks/index.js';
 import type { PokemonWithFinalContribution, PokemonWithRecipeContributions, PokemonWithTiering } from 'sleepapi-common';
 import { describe, expect, it } from 'vitest';
 import { CookingTierlist } from './cooking-tier-list.js';
@@ -11,7 +11,7 @@ describe('tierAndDiff', () => {
       totalIngredients: Float32Array.prototype,
       critMultiplier: 1,
       averageWeekdayPotSize: 1,
-      settings: teamMemberSettings.prototype
+      settings: teamMemberSettingsDto.prototype
     };
 
     // Create 20 Pokemon with decreasing scores to ensure we exhaust all tier buckets
@@ -43,7 +43,7 @@ describe('tierAndDiff', () => {
       totalIngredients: Float32Array.prototype,
       critMultiplier: 1,
       averageWeekdayPotSize: 1,
-      settings: teamMemberSettings.prototype
+      settings: teamMemberSettingsDto.prototype
     };
 
     const mockContributions: PokemonWithFinalContribution[] = [
@@ -65,7 +65,7 @@ describe('tierAndDiff', () => {
       totalIngredients: Float32Array.prototype,
       critMultiplier: 1,
       averageWeekdayPotSize: 1,
-      settings: teamMemberSettings.prototype
+      settings: teamMemberSettingsDto.prototype
     };
 
     // Close scores that should not exhaust all tiers

--- a/backend/src/services/tier-list/cooking-tier-list.ts
+++ b/backend/src/services/tier-list/cooking-tier-list.ts
@@ -23,8 +23,8 @@ import type {
   PokemonWithFinalContribution,
   PokemonWithTiering,
   Recipe,
-  SolveSettingsExt,
-  TeamMemberExt,
+  SolveSettings,
+  TeamMember,
   Tier,
   TierlistSettings,
   Time
@@ -126,7 +126,7 @@ class CookingTierlistImpl {
 
   private generate(settings: TierlistSettings, userRecipes: UserRecipes) {
     const { level, camp } = settings;
-    const solveSettings: SolveSettingsExt = {
+    const solveSettings: SolveSettings = {
       bedtime: this.bedtime,
       camp,
       level,
@@ -210,8 +210,8 @@ class CookingTierlistImpl {
   }
 
   private calculateProductionAll(params: {
-    solveSettings: SolveSettingsExt;
-    supportMember?: TeamMemberExt;
+    solveSettings: SolveSettings;
+    supportMember?: TeamMember;
     userRecipes: UserRecipes;
   }): {
     productionMap: Map<string, SetCoverPokemonSetupWithSettings>;
@@ -240,7 +240,7 @@ class CookingTierlistImpl {
   private getIngredientListsAndSupportMap(params: {
     pkmn: Pokemon;
     isSupport: boolean;
-    solveSettings: SolveSettingsExt;
+    solveSettings: SolveSettings;
     userRecipes: UserRecipes;
     defaultProductionMap: Map<string, SetCoverPokemonSetupWithSettings>;
   }): {
@@ -255,7 +255,7 @@ class CookingTierlistImpl {
     // if this is a support mon
     // re-calculate production for all other pokemon with this support mon included in team
     if (isSupport) {
-      const supportMember: TeamMemberExt = pokedexToMembers({
+      const supportMember: TeamMember = pokedexToMembers({
         pokedex: [pkmn],
         level: solveSettings.level,
         camp: solveSettings.camp

--- a/backend/src/vitest/mocks/solve/mock-solve-settings.ts
+++ b/backend/src/vitest/mocks/solve/mock-solve-settings.ts
@@ -1,7 +1,7 @@
 import { mocks } from '@src/vitest/index.js';
-import { type SolveSettings, type SolveSettingsExt } from 'sleepapi-common';
+import { type SolveSettings, type SolveSettingsDto } from 'sleepapi-common';
 
-export function solveSettings(attrs?: Partial<SolveSettings>): SolveSettings {
+export function solveSettingsDto(attrs?: Partial<SolveSettingsDto>): SolveSettingsDto {
   return {
     camp: false,
     bedtime: mocks.BEDTIME,
@@ -13,7 +13,7 @@ export function solveSettings(attrs?: Partial<SolveSettings>): SolveSettings {
   };
 }
 
-export function solveSettingsExt(attrs?: Partial<SolveSettingsExt>): SolveSettingsExt {
+export function solveSettings(attrs?: Partial<SolveSettings>): SolveSettings {
   return {
     camp: false,
     bedtime: mocks.bedtime(),

--- a/backend/src/vitest/mocks/team/mock-cooking-state.ts
+++ b/backend/src/vitest/mocks/team/mock-cooking-state.ts
@@ -4,5 +4,5 @@ import { createPreGeneratedRandom } from '@src/utils/random-utils/pre-generated-
 import { mocks } from '@src/vitest/index.js';
 
 export function cookingState(provided?: CookingState): CookingState {
-  return provided ?? new CookingState(mocks.teamSettingsExt(), defaultUserRecipes(), createPreGeneratedRandom());
+  return provided ?? new CookingState(mocks.teamSettings(), defaultUserRecipes(), createPreGeneratedRandom());
 }

--- a/backend/src/vitest/mocks/team/mock-member-state.ts
+++ b/backend/src/vitest/mocks/team/mock-member-state.ts
@@ -1,13 +1,13 @@
 import { MemberState } from '@src/services/simulation-service/team-simulator/member-state/member-state.js';
 import { createPreGeneratedRandom } from '@src/utils/random-utils/pre-generated-random.js';
 import { mocks } from '@src/vitest/index.js';
-import { teamMemberExt } from '@src/vitest/mocks/team/mock-team-member-ext.js';
+import { teamMember } from '@src/vitest/mocks/team/mock-team-member-ext.js';
 
 export function memberState(attrs?: Partial<MemberState>): MemberState {
   return new MemberState({
-    member: teamMemberExt(),
-    settings: mocks.teamSettingsExt(),
-    team: [teamMemberExt()],
+    member: teamMember(),
+    settings: mocks.teamSettings(),
+    team: [teamMember()],
     cookingState: undefined,
     iterations: 1,
     rng: createPreGeneratedRandom(),

--- a/backend/src/vitest/mocks/team/mock-simple-team-results.ts
+++ b/backend/src/vitest/mocks/team/mock-simple-team-results.ts
@@ -1,4 +1,4 @@
-import { teamMemberExt } from '@src/vitest/mocks/team/mock-team-member-ext.js';
+import { teamMember } from '@src/vitest/mocks/team/mock-team-member-ext.js';
 import type { SimpleTeamResult } from 'sleepapi-common';
 import { commonMocks } from 'sleepapi-common';
 
@@ -7,7 +7,7 @@ export function simpleTeamResult(attrs?: Partial<SimpleTeamResult>): SimpleTeamR
     averageWeekdayPotSize: 0,
     critMultiplier: 2,
     ingredientPercentage: 20,
-    member: teamMemberExt(),
+    member: teamMember(),
     skillIngredients: commonMocks.mockIngredientSetFloatIndexed(),
     skillProcs: 0,
     totalHelps: 0,

--- a/backend/src/vitest/mocks/team/mock-team-member-ext.ts
+++ b/backend/src/vitest/mocks/team/mock-team-member-ext.ts
@@ -1,11 +1,11 @@
 import { pokemonWithIngredients } from '@src/vitest/mocks/pokemon/mock-pokemon-with-ingredients.js';
-import { teamMemberSettingsExt } from '@src/vitest/mocks/team/mock-team-member-settings-ext.js';
-import type { TeamMemberExt } from 'sleepapi-common';
+import { teamMemberSettings } from '@src/vitest/mocks/team/mock-team-member-settings-ext.js';
+import type { TeamMember } from 'sleepapi-common';
 
-export function teamMemberExt(attrs?: Partial<TeamMemberExt>): TeamMemberExt {
+export function teamMember(attrs?: Partial<TeamMember>): TeamMember {
   return {
     pokemonWithIngredients: pokemonWithIngredients(),
-    settings: teamMemberSettingsExt(),
+    settings: teamMemberSettings(),
     ...attrs
   };
 }

--- a/backend/src/vitest/mocks/team/mock-team-member-settings-ext.ts
+++ b/backend/src/vitest/mocks/team/mock-team-member-settings-ext.ts
@@ -1,7 +1,7 @@
-import type { TeamMemberSettings, TeamMemberSettingsExt, TeamMemberSettingsResult } from 'sleepapi-common';
+import type { TeamMemberSettings, TeamMemberSettingsDto, TeamMemberSettingsResult } from 'sleepapi-common';
 import { nature } from 'sleepapi-common';
 
-export function teamMemberSettings(attrs?: Partial<TeamMemberSettings>): TeamMemberSettings {
+export function teamMemberSettingsDto(attrs?: Partial<TeamMemberSettingsDto>): TeamMemberSettingsDto {
   return {
     carrySize: 0,
     externalId: 'mock id',
@@ -15,7 +15,7 @@ export function teamMemberSettings(attrs?: Partial<TeamMemberSettings>): TeamMem
   };
 }
 
-export function teamMemberSettingsExt(attrs?: Partial<TeamMemberSettingsExt>): TeamMemberSettingsExt {
+export function teamMemberSettings(attrs?: Partial<TeamMemberSettings>): TeamMemberSettings {
   return {
     carrySize: 1,
     externalId: 'mock id',

--- a/common/src/events/applier/event-applier.test.ts
+++ b/common/src/events/applier/event-applier.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import type { PokemonInstanceExt } from '../../types';
+import type { PokemonInstance } from '../../types';
 import type { Event } from '../../types/events/event-types';
 import { ChargeEnergyS } from '../../types/mainskill/mainskills/charge-energy-s';
 import type { ExternalCondition, Modifier } from '../../types/modifier/modifier';
 import { PathReference } from '../../types/modifier/path-reference';
 import type { ModifierTargetType } from '../../types/modifier/target-types';
 import { mockPokemon } from '../../vitest/mocks/pokemon/mock-pokemon';
-import { pokemonInstanceExt } from '../../vitest/mocks/pokemon/mock-pokemon-instance';
+import { pokemonInstance } from '../../vitest/mocks/pokemon/mock-pokemon-instance';
 import { EventApplier } from './event-applier';
 
 describe('EventApplier', () => {
   describe('applyModifiers', () => {
     it('should apply a simple modifier to a PokemonInstance', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -20,7 +20,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '*',
             rightValue: 0.9
@@ -34,7 +34,7 @@ describe('EventApplier', () => {
     });
 
     it('should not apply modifiers with non-existent paths', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -42,7 +42,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             // @ts-expect-error - Testing non-existent property
             leftValue: 'nonExistentProperty',
             operation: '*',
@@ -57,7 +57,7 @@ describe('EventApplier', () => {
     });
 
     it('should apply modifier with condition when condition is met', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400, specialty: 'skill' })
       });
       const event: Event = {
@@ -65,7 +65,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '*',
             rightValue: 0.9,
@@ -87,7 +87,7 @@ describe('EventApplier', () => {
     });
 
     it('should not apply modifier when condition is not met', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400, specialty: 'skill' })
       });
       const event: Event = {
@@ -95,7 +95,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '*',
             rightValue: 0.9,
@@ -117,7 +117,7 @@ describe('EventApplier', () => {
     });
 
     it('should apply all modifiers when multiple conditions are met', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400, specialty: 'skill' })
       });
       const event: Event = {
@@ -125,7 +125,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '*',
             rightValue: 0.9,
@@ -152,7 +152,7 @@ describe('EventApplier', () => {
     });
 
     it('should not apply modifier when any condition in conditions array is not met', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400, specialty: 'skill' })
       });
       const event: Event = {
@@ -160,7 +160,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '*',
             rightValue: 0.9,
@@ -187,7 +187,7 @@ describe('EventApplier', () => {
     });
 
     it('should handle path reference in condition value', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         level: 50,
         skillLevel: 3,
         pokemon: mockPokemon({
@@ -200,7 +200,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '*',
             rightValue: 0.9,
@@ -222,7 +222,7 @@ describe('EventApplier', () => {
     });
 
     it('should apply multiple operations correctly', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -230,13 +230,13 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '+',
             rightValue: 100
           },
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '*',
             rightValue: 0.5
@@ -251,7 +251,7 @@ describe('EventApplier', () => {
     });
 
     it('should handle = operation', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -259,7 +259,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '=',
             rightValue: 1000
@@ -273,7 +273,7 @@ describe('EventApplier', () => {
     });
 
     it('should handle - operation', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -281,7 +281,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '-',
             rightValue: 100
@@ -295,7 +295,7 @@ describe('EventApplier', () => {
     });
 
     it('should handle / operation', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -303,7 +303,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '/',
             rightValue: 2
@@ -317,7 +317,7 @@ describe('EventApplier', () => {
     });
 
     it('should apply constrained subtraction with min floor', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -325,7 +325,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '-',
             rightValue: {
@@ -343,7 +343,7 @@ describe('EventApplier', () => {
     });
 
     it("should not apply modifiers that don't match target type", () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -351,7 +351,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'MemberStrength', // Different type
+            type: 'MemberStrengthDto', // Different type
             // @ts-expect-error - Testing type mismatch
             leftValue: 'memberProduction.berries',
             operation: '*',
@@ -367,7 +367,7 @@ describe('EventApplier', () => {
     });
 
     it('should apply constrained addition with max ceiling', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -375,7 +375,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '+',
             rightValue: {
@@ -393,7 +393,7 @@ describe('EventApplier', () => {
     });
 
     it('should apply constrained addition with PathReference max', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         level: 50,
         skillLevel: 3,
         pokemon: mockPokemon({
@@ -406,7 +406,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'skillLevel',
             operation: '+',
             rightValue: {
@@ -424,7 +424,7 @@ describe('EventApplier', () => {
     });
 
     it('should apply constrained subtraction with min floor on skill level', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         level: 50,
         skillLevel: 3,
         pokemon: mockPokemon({
@@ -437,7 +437,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'skillLevel',
             operation: '-',
             rightValue: {
@@ -455,7 +455,7 @@ describe('EventApplier', () => {
     });
 
     it('should apply operation with both min and max constraints', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 1000 })
       });
       const event: Event = {
@@ -463,7 +463,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '*',
             rightValue: {
@@ -482,7 +482,7 @@ describe('EventApplier', () => {
     });
 
     it('should handle complex modifier without constraint', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -490,7 +490,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '*',
             rightValue: {
@@ -506,7 +506,7 @@ describe('EventApplier', () => {
     });
 
     it('should handle in operator in conditions', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ specialty: 'skill' })
       });
       const event: Event = {
@@ -514,7 +514,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.specialty',
             operation: '=',
             rightValue: 'berry',
@@ -536,7 +536,7 @@ describe('EventApplier', () => {
     });
 
     it('should handle not-in operator in conditions', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ specialty: 'all' })
       });
       const event: Event = {
@@ -544,7 +544,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.specialty',
             operation: '=',
             rightValue: 'berry',
@@ -566,7 +566,7 @@ describe('EventApplier', () => {
     });
 
     it('should apply external conditions correctly', () => {
-      const pokemon = pokemonInstanceExt({
+      const pokemon = pokemonInstance({
         pokemon: mockPokemon({ frequency: 2400 })
       });
       const event: Event = {
@@ -574,7 +574,7 @@ describe('EventApplier', () => {
         description: 'Test',
         modifiers: [
           {
-            type: 'PokemonInstance',
+            type: 'PokemonInstanceDto',
             leftValue: 'pokemon.frequency',
             operation: '*',
             rightValue: 0.9,
@@ -590,7 +590,7 @@ describe('EventApplier', () => {
       };
 
       // Mock external condition to return true
-      const applyModifiersWithExternals = (target: PokemonInstanceExt, modifiers: Modifier<ModifierTargetType>[]) => {
+      const applyModifiersWithExternals = (target: PokemonInstance, modifiers: Modifier<ModifierTargetType>[]) => {
         // This is a simplified version - actual implementation would need to handle externals
         return EventApplier.applyModifiers(target, modifiers);
       };

--- a/common/src/events/builders/event-builder.test.ts
+++ b/common/src/events/builders/event-builder.test.ts
@@ -58,7 +58,7 @@ describe('EventBuilder', () => {
       // For void input with modifiers, we get a function that we need to call
       const event = (eventFactory as unknown as () => FunctionalEvent)();
 
-      const mockPokemon = commonMocks.pokemonInstanceExt({
+      const mockPokemon = commonMocks.pokemonInstance({
         pokemon: commonMocks.mockPokemon({ frequency: 1000 })
       });
 
@@ -82,11 +82,11 @@ describe('EventBuilder', () => {
 
       const event = (eventFactory as unknown as () => FunctionalEvent)();
 
-      const berrySpecialist = commonMocks.pokemonInstanceExt({
+      const berrySpecialist = commonMocks.pokemonInstance({
         pokemon: commonMocks.mockPokemon({ frequency: 1000, specialty: 'berry' })
       });
 
-      const nonBerrySpecialist = commonMocks.pokemonInstanceExt({
+      const nonBerrySpecialist = commonMocks.pokemonInstance({
         pokemon: commonMocks.mockPokemon({ frequency: 1000, specialty: 'ingredient' })
       });
 
@@ -108,7 +108,7 @@ describe('EventBuilder', () => {
 
       const event = (eventFactory as unknown as () => FunctionalEvent)();
 
-      const mockPokemon = commonMocks.pokemonInstanceExt({ skillLevel: 5 });
+      const mockPokemon = commonMocks.pokemonInstance({ skillLevel: 5 });
 
       const result = event.applyToPokemon(mockPokemon);
       expect(result.skillLevel).toBe(10);
@@ -141,8 +141,8 @@ describe('EventBuilder', () => {
 
       const event = (eventFactory as unknown as () => FunctionalEvent)();
 
-      const mockMember = commonMocks.teamMemberExt({
-        settings: commonMocks.teamMemberSettingsExt({ skillLevel: 5 })
+      const mockMember = commonMocks.teamMember({
+        settings: commonMocks.teamMemberSettings({ skillLevel: 5 })
       });
 
       const result = event.applyToTeam(mockMember);
@@ -160,7 +160,7 @@ describe('EventBuilder', () => {
 
       const event = (eventFactory as unknown as () => FunctionalEvent)();
 
-      const mockMember = commonMocks.teamMemberExt({
+      const mockMember = commonMocks.teamMember({
         pokemonWithIngredients: commonMocks.pokemonWithIngredients({
           pokemon: commonMocks.mockPokemon({ frequency: 1000 })
         })
@@ -203,7 +203,7 @@ describe('EventBuilder', () => {
       expect(event1.name).toBe('Dynamic Event');
       expect(event2.name).toBe('Dynamic Event');
 
-      const mockPokemon = commonMocks.pokemonInstanceExt({
+      const mockPokemon = commonMocks.pokemonInstance({
         pokemon: commonMocks.mockPokemon({ frequency: 1000 })
       });
 
@@ -274,7 +274,7 @@ describe('EventBuilder', () => {
       })(false, true);
 
       // Test with MAGO berry (main favorite)
-      const magoPokemon = commonMocks.pokemonInstanceExt({
+      const magoPokemon = commonMocks.pokemonInstance({
         pokemon: commonMocks.mockPokemon({
           berry: MAGO,
           frequency: 1000,
@@ -290,7 +290,7 @@ describe('EventBuilder', () => {
       expect(result.pokemon.skillPercentage).toBe(125); // 25% boost
 
       // Test with non-favored berry (ORAN is in subFavoriteBerries, so use BELUE which is not favored)
-      const otherPokemon = commonMocks.pokemonInstanceExt({
+      const otherPokemon = commonMocks.pokemonInstance({
         pokemon: commonMocks.mockPokemon({
           berry: commonMocks.mockPokemon().berry, // Use BELUE (default mock berry) which is not in favored list
           frequency: 1000,
@@ -340,7 +340,7 @@ describe('EventBuilder', () => {
 
       const event = (eventFactory as unknown as () => FunctionalEvent)();
 
-      const mockPokemon = commonMocks.pokemonInstanceExt({
+      const mockPokemon = commonMocks.pokemonInstance({
         pokemon: commonMocks.mockPokemon({ frequency: 1000 }),
         skillLevel: 5
       });
@@ -363,7 +363,7 @@ describe('EventBuilder', () => {
 
       const event = (eventFactory as unknown as () => FunctionalEvent)();
 
-      const original = commonMocks.pokemonInstanceExt({
+      const original = commonMocks.pokemonInstance({
         pokemon: commonMocks.mockPokemon({ frequency: 1000 })
       });
 

--- a/common/src/events/builders/event-builder.ts
+++ b/common/src/events/builders/event-builder.ts
@@ -1,12 +1,12 @@
-import type { MemberStrength, PokemonInstanceExt, TeamMemberExt } from '../../types';
+import type { MemberStrength, PokemonInstance, TeamMember } from '../../types';
 import type { PathValue } from '../../types/type/path-value';
 import type { PathKeys } from '../../types/type/type-paths';
 
 export interface FunctionalEvent {
   name: string;
   description: string;
-  applyToPokemon: (target: PokemonInstanceExt) => PokemonInstanceExt;
-  applyToTeam: (target: TeamMemberExt) => TeamMemberExt;
+  applyToPokemon: (target: PokemonInstance) => PokemonInstance;
+  applyToTeam: (target: TeamMember) => TeamMember;
   applyToStrength: (target: MemberStrength) => MemberStrength;
 }
 
@@ -26,8 +26,8 @@ export class EventBuilder<TInput = void> {
   private eventName?: string;
   private eventDescription?: string;
 
-  private pokemonModifiers: Array<(input: TInput, target: PokemonInstanceExt) => Record<string, unknown>> = [];
-  private teamModifiers: Array<(input: TInput, target: TeamMemberExt) => Record<string, unknown>> = [];
+  private pokemonModifiers: Array<(input: TInput, target: PokemonInstance) => Record<string, unknown>> = [];
+  private teamModifiers: Array<(input: TInput, target: TeamMember) => Record<string, unknown>> = [];
   private strengthModifiers: Array<(input: TInput, target: MemberStrength) => Record<string, unknown>> = [];
 
   /**
@@ -63,7 +63,7 @@ export class EventBuilder<TInput = void> {
    *   'skillLevel': (level) => level + 1
    * }))
    */
-  forPokemon(factory: (input: TInput, target: PokemonInstanceExt) => ModifierMap<PokemonInstanceExt>): this {
+  forPokemon(factory: (input: TInput, target: PokemonInstance) => ModifierMap<PokemonInstance>): this {
     this.pokemonModifiers.push((input, target) => factory(input, target));
     return this;
   }
@@ -77,7 +77,7 @@ export class EventBuilder<TInput = void> {
    *   'pokemonWithIngredients.pokemon.frequency': (freq) => freq * 0.9,
    * }))
    */
-  forTeam(factory: (input: TInput, target: TeamMemberExt) => ModifierMap<TeamMemberExt>): this {
+  forTeam(factory: (input: TInput, target: TeamMember) => ModifierMap<TeamMember>): this {
     this.teamModifiers.push((input, target) => factory(input, target));
     return this;
   }
@@ -114,8 +114,8 @@ export class EventBuilder<TInput = void> {
       const noOpEvent: FunctionalEvent = {
         name: this.eventName,
         description: this.eventDescription,
-        applyToPokemon: (p: PokemonInstanceExt) => p,
-        applyToTeam: (t: TeamMemberExt) => t,
+        applyToPokemon: (p: PokemonInstance) => p,
+        applyToTeam: (t: TeamMember) => t,
         applyToStrength: (s: MemberStrength) => s
       };
       return noOpEvent as TInput extends void ? FunctionalEvent : (input: TInput) => FunctionalEvent;
@@ -126,7 +126,7 @@ export class EventBuilder<TInput = void> {
         name: this.eventName!,
         description: this.eventDescription!,
 
-        applyToPokemon: (target: PokemonInstanceExt): PokemonInstanceExt => {
+        applyToPokemon: (target: PokemonInstance): PokemonInstance => {
           let result = target;
           for (const factory of this.pokemonModifiers) {
             result = this.applyModifierMap(result, factory(input, result));
@@ -134,7 +134,7 @@ export class EventBuilder<TInput = void> {
           return result;
         },
 
-        applyToTeam: (target: TeamMemberExt): TeamMemberExt => {
+        applyToTeam: (target: TeamMember): TeamMember => {
           let result = target;
           for (const factory of this.teamModifiers) {
             result = this.applyModifierMap(result, factory(input, result));

--- a/common/src/events/events/2025-08-11-greengrass-expert-mode.ts
+++ b/common/src/events/events/2025-08-11-greengrass-expert-mode.ts
@@ -1,11 +1,11 @@
-import type { ExpertModeSettings, TeamMemberExt } from '../../types';
+import type { ExpertModeSettings, TeamMember } from '../../types';
 import { EventBuilder } from '../builders/event-builder';
 
-function isMainBerry(input: ExpertModeSettings, member: TeamMemberExt) {
+function isMainBerry(input: ExpertModeSettings, member: TeamMember) {
   return input.mainFavoriteBerry.name === member.pokemonWithIngredients.pokemon.berry.name;
 }
 
-function isFavoredBerry(input: ExpertModeSettings, member: TeamMemberExt) {
+function isFavoredBerry(input: ExpertModeSettings, member: TeamMember) {
   const berryName = member.pokemonWithIngredients.pokemon.berry.name;
   return input.mainFavoriteBerry.name === berryName || input.subFavoriteBerries.some((b) => b.name === berryName);
 }

--- a/common/src/events/events/2026-08-06-cyan-expert-mode.ts
+++ b/common/src/events/events/2026-08-06-cyan-expert-mode.ts
@@ -1,11 +1,11 @@
-import type { ExpertModeSettings, TeamMemberExt } from '../../types';
+import type { ExpertModeSettings, TeamMember } from '../../types';
 import { EventBuilder } from '../builders/event-builder';
 
-function isMainBerry(input: ExpertModeSettings, member: TeamMemberExt) {
+function isMainBerry(input: ExpertModeSettings, member: TeamMember) {
   return input.mainFavoriteBerry.name === member.pokemonWithIngredients.pokemon.berry.name;
 }
 
-function isFavoredBerry(input: ExpertModeSettings, member: TeamMemberExt) {
+function isFavoredBerry(input: ExpertModeSettings, member: TeamMember) {
   const berryName = member.pokemonWithIngredients.pokemon.berry.name;
   return input.mainFavoriteBerry.name === berryName || input.subFavoriteBerries.some((b) => b.name === berryName);
 }

--- a/common/src/types/instance/ingredient-instance.ts
+++ b/common/src/types/instance/ingredient-instance.ts
@@ -1,12 +1,12 @@
 import type { Ingredient } from '../ingredient/ingredient';
 
-export interface IngredientInstance {
+export interface IngredientInstanceDto {
   level: number;
   amount: number;
   name: string;
 }
 
-export interface IngredientInstanceExt {
+export interface IngredientInstance {
   level: number;
   amount: number;
   ingredient: Ingredient;

--- a/common/src/types/instance/pokemon-instance.ts
+++ b/common/src/types/instance/pokemon-instance.ts
@@ -1,8 +1,8 @@
 import type { PokemonGender } from '../gender/gender';
 import type { Nature } from '../nature/nature';
 import type { Pokemon } from '../pokemon/pokemon';
-import type { IngredientInstance, IngredientInstanceExt } from './ingredient-instance';
-import type { SubskillInstance, SubskillInstanceExt } from './subskill-instance';
+import type { IngredientInstance, IngredientInstanceDto } from './ingredient-instance';
+import type { SubskillInstance, SubskillInstanceDto } from './subskill-instance';
 
 export interface PokemonInstanceBase<PokemonType, NatureType, SubskillType, IngredientType> {
   pokemon: PokemonType;
@@ -15,11 +15,11 @@ export interface PokemonInstanceBase<PokemonType, NatureType, SubskillType, Ingr
   ingredients: IngredientType[];
   sneakySnacking: boolean;
 }
-export type PokemonInstance = PokemonInstanceBase<
+export type PokemonInstanceDto = PokemonInstanceBase<
   string, // Pokemon as a simple string ID
   string, // Nature as a string
-  SubskillInstance, // Simple representation of subskills
-  IngredientInstance // simple representation of ingredients
+  SubskillInstanceDto, // Simple representation of subskills
+  IngredientInstanceDto // simple representation of ingredients
 >;
 
 export interface PokemonInstanceMeta {
@@ -30,9 +30,9 @@ export interface PokemonInstanceMeta {
   gender: PokemonGender;
   name: string;
 }
-export type PokemonInstanceWithMeta = PokemonInstance & PokemonInstanceMeta;
+export type PokemonInstanceWithMeta = PokemonInstanceDto & PokemonInstanceMeta;
 
-export interface PokemonInstanceExt
-  extends PokemonInstanceBase<Pokemon, Nature, SubskillInstanceExt, IngredientInstanceExt>, PokemonInstanceMeta {
+export interface PokemonInstance
+  extends PokemonInstanceBase<Pokemon, Nature, SubskillInstance, IngredientInstance>, PokemonInstanceMeta {
   rp: number;
 }

--- a/common/src/types/instance/subskill-instance.ts
+++ b/common/src/types/instance/subskill-instance.ts
@@ -1,10 +1,10 @@
 import type { Subskill } from '../subskill/subskill';
 
-export interface SubskillInstance {
+export interface SubskillInstanceDto {
   level: number;
   subskill: string;
 }
-export interface SubskillInstanceExt {
+export interface SubskillInstance {
   level: number;
   subskill: Subskill;
 }

--- a/common/src/types/modifier/modifier.test.ts
+++ b/common/src/types/modifier/modifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { PokemonInstanceExt } from '../instance';
+import type { PokemonInstance } from '../instance';
 import type { ConditionOperation, Modifier, ModifierOperation } from './modifier';
 
 describe('Modifier', () => {
@@ -29,8 +29,8 @@ describe('Modifier', () => {
 
   describe('Modifier', () => {
     it('should create a valid modifier', () => {
-      const modifier: Modifier<PokemonInstanceExt> = {
-        type: 'PokemonInstance',
+      const modifier: Modifier<PokemonInstance> = {
+        type: 'PokemonInstanceDto',
         leftValue: 'pokemon.frequency',
         operation: '*',
         rightValue: 0.9,
@@ -43,7 +43,7 @@ describe('Modifier', () => {
         ]
       };
 
-      expect(modifier.type).toBe('PokemonInstance');
+      expect(modifier.type).toBe('PokemonInstanceDto');
       expect(modifier.leftValue).toBe('pokemon.frequency');
       expect(modifier.operation).toBe('*');
       expect(modifier.rightValue).toBe(0.9);
@@ -64,22 +64,22 @@ describe('Modifier', () => {
 
     it('should infer the correct type for value from the path', () => {
       // valid case
-      const modifier: Modifier<PokemonInstanceExt> = {
-        type: 'PokemonInstance',
+      const modifier: Modifier<PokemonInstance> = {
+        type: 'PokemonInstanceDto',
         leftValue: 'pokemon.frequency',
         operation: '*',
         rightValue: 0.9
       };
 
-      expect(modifier.type).toBe('PokemonInstance');
+      expect(modifier.type).toBe('PokemonInstanceDto');
       expect(modifier.leftValue).toBe('pokemon.frequency');
       expect(modifier.operation).toBe('*');
       expect(modifier.rightValue).toBe(0.9);
 
       // invalid case - wrong value type
       // @ts-expect-error - invalid type, should be number
-      const invalidModifier: Modifier<PokemonInstanceExt> = {
-        type: 'PokemonInstance',
+      const invalidModifier: Modifier<PokemonInstance> = {
+        type: 'PokemonInstanceDto',
         leftValue: 'pokemon.frequency',
         operation: '*',
         rightValue: '0.9'
@@ -90,21 +90,21 @@ describe('Modifier', () => {
 
     it('should infer the correct paths', () => {
       // valid case
-      const modifier: Modifier<PokemonInstanceExt> = {
-        type: 'PokemonInstance',
+      const modifier: Modifier<PokemonInstance> = {
+        type: 'PokemonInstanceDto',
         leftValue: 'pokemon.frequency',
         operation: '*',
         rightValue: 0.9
       };
 
-      expect(modifier.type).toBe('PokemonInstance');
+      expect(modifier.type).toBe('PokemonInstanceDto');
       expect(modifier.leftValue).toBe('pokemon.frequency');
       expect(modifier.operation).toBe('*');
       expect(modifier.rightValue).toBe(0.9);
 
       // invalid case
-      const invalidModifier: Modifier<PokemonInstanceExt> = {
-        type: 'PokemonInstance',
+      const invalidModifier: Modifier<PokemonInstance> = {
+        type: 'PokemonInstanceDto',
         // @ts-expect-error - invalid leftValue
         leftValue: 'invalid',
         operation: '*',

--- a/common/src/types/modifier/path-reference.test.ts
+++ b/common/src/types/modifier/path-reference.test.ts
@@ -1,56 +1,56 @@
 import { describe, expect, it } from 'vitest';
-import type { PokemonInstanceExt } from '../../types';
+import type { PokemonInstance } from '../../types';
 import { PathReference, isPathReference, pathRef } from './path-reference';
 
 describe('PathReference', () => {
   describe('constructor', () => {
     it('should create a PathReference with a path', () => {
-      const pathRef = new PathReference<PokemonInstanceExt>('name');
+      const pathRef = new PathReference<PokemonInstance>('name');
       expect(pathRef.path).toBe('name');
     });
 
     it('should support nested paths', () => {
-      const pathRef = new PathReference<PokemonInstanceExt>('pokemon.berry.name');
+      const pathRef = new PathReference<PokemonInstance>('pokemon.berry.name');
       expect(pathRef.path).toBe('pokemon.berry.name');
     });
 
     it('should support array paths', () => {
-      const pathRef = new PathReference<PokemonInstanceExt>('pokemon.ingredient0.0.amount');
+      const pathRef = new PathReference<PokemonInstance>('pokemon.ingredient0.0.amount');
       expect(pathRef.path).toBe('pokemon.ingredient0.0.amount');
     });
 
     it('should support wildcard array paths', () => {
-      const pathRef = new PathReference<PokemonInstanceExt>('pokemon.ingredient0.*.amount');
+      const pathRef = new PathReference<PokemonInstance>('pokemon.ingredient0.*.amount');
       expect(pathRef.path).toBe('pokemon.ingredient0.*.amount');
     });
   });
 
   describe('static to() method', () => {
     it('should create a PathReference using static method', () => {
-      const pathRef = PathReference.to<PokemonInstanceExt>('pokemon.frequency');
+      const pathRef = PathReference.to<PokemonInstance>('pokemon.frequency');
       expect(pathRef).toBeInstanceOf(PathReference);
       expect(pathRef.path).toBe('pokemon.frequency');
     });
 
     it('should support Pokemon instance paths', () => {
-      const pathRef = PathReference.to<PokemonInstanceExt>('pokemon.name');
+      const pathRef = PathReference.to<PokemonInstance>('pokemon.name');
       expect(pathRef.path).toBe('pokemon.name');
     });
 
     it('should support deeply nested paths', () => {
-      const pathRef = PathReference.to<PokemonInstanceExt>('pokemon.berry.name');
+      const pathRef = PathReference.to<PokemonInstance>('pokemon.berry.name');
       expect(pathRef.path).toBe('pokemon.berry.name');
     });
 
     it('should support skill-related paths', () => {
-      const pathRef = PathReference.to<PokemonInstanceExt>('pokemon.skill.maxLevel');
+      const pathRef = PathReference.to<PokemonInstance>('pokemon.skill.maxLevel');
       expect(pathRef.path).toBe('pokemon.skill.maxLevel');
     });
   });
 
   describe('isPathReference type guard', () => {
     it('should return true for PathReference instances', () => {
-      const pathRef = PathReference.to<PokemonInstanceExt>('name');
+      const pathRef = PathReference.to<PokemonInstance>('name');
       expect(isPathReference(pathRef)).toBe(true);
     });
 
@@ -64,7 +64,7 @@ describe('PathReference', () => {
     });
 
     it('should work as a type guard in conditional blocks', () => {
-      const value: unknown = PathReference.to<PokemonInstanceExt>('pokemon.frequency');
+      const value: unknown = PathReference.to<PokemonInstance>('pokemon.frequency');
 
       if (isPathReference(value)) {
         // TypeScript should know this is a PathReference
@@ -78,15 +78,15 @@ describe('PathReference', () => {
 
   describe('pathRef helper function', () => {
     it('should create a PathReference using helper function', () => {
-      const pathReference = pathRef<PokemonInstanceExt>('pokemon.specialty');
+      const pathReference = pathRef<PokemonInstance>('pokemon.specialty');
       expect(pathReference).toBeInstanceOf(PathReference);
       expect(pathReference.path).toBe('pokemon.specialty');
     });
 
     it('should be equivalent to PathReference.to()', () => {
       const path = 'pokemon.ingredientPercentage' as const;
-      const pathRef1 = pathRef<PokemonInstanceExt>(path);
-      const pathRef2 = PathReference.to<PokemonInstanceExt>(path);
+      const pathRef1 = pathRef<PokemonInstance>(path);
+      const pathRef2 = PathReference.to<PokemonInstance>(path);
 
       expect(pathRef1.path).toBe(pathRef2.path);
       expect(pathRef1).toBeInstanceOf(PathReference);
@@ -98,11 +98,11 @@ describe('PathReference', () => {
     it('should enforce type-safe paths for Pokemon', () => {
       // These should compile without errors
       const validPaths = [
-        PathReference.to<PokemonInstanceExt>('pokemon.name'),
-        PathReference.to<PokemonInstanceExt>('pokemon.frequency'),
-        PathReference.to<PokemonInstanceExt>('pokemon.berry.name'),
-        PathReference.to<PokemonInstanceExt>('pokemon.skill.maxLevel'),
-        PathReference.to<PokemonInstanceExt>('pokemon.ingredient0.0.amount')
+        PathReference.to<PokemonInstance>('pokemon.name'),
+        PathReference.to<PokemonInstance>('pokemon.frequency'),
+        PathReference.to<PokemonInstance>('pokemon.berry.name'),
+        PathReference.to<PokemonInstance>('pokemon.skill.maxLevel'),
+        PathReference.to<PokemonInstance>('pokemon.ingredient0.0.amount')
       ];
 
       validPaths.forEach((pathRef) => {
@@ -111,15 +111,15 @@ describe('PathReference', () => {
       });
     });
 
-    it('should enforce type-safe paths for PokemonInstanceExt', () => {
+    it('should enforce type-safe paths for PokemonInstance', () => {
       // These should compile without errors
       const validPaths = [
-        PathReference.to<PokemonInstanceExt>('skillLevel'),
-        PathReference.to<PokemonInstanceExt>('pokemon.name'),
-        PathReference.to<PokemonInstanceExt>('pokemon.frequency'),
-        PathReference.to<PokemonInstanceExt>('pokemon.berry.name'),
-        PathReference.to<PokemonInstanceExt>('level'),
-        PathReference.to<PokemonInstanceExt>('ribbon')
+        PathReference.to<PokemonInstance>('skillLevel'),
+        PathReference.to<PokemonInstance>('pokemon.name'),
+        PathReference.to<PokemonInstance>('pokemon.frequency'),
+        PathReference.to<PokemonInstance>('pokemon.berry.name'),
+        PathReference.to<PokemonInstance>('level'),
+        PathReference.to<PokemonInstance>('ribbon')
       ];
 
       validPaths.forEach((pathRef) => {
@@ -130,22 +130,22 @@ describe('PathReference', () => {
 
     it('should reject invalid paths at compile time', () => {
       // @ts-expect-error - invalid path
-      PathReference.to<PokemonInstanceExt>('invalidPath');
+      PathReference.to<PokemonInstance>('invalidPath');
       // @ts-expect-error - invalid path
-      pathRef<PokemonInstanceExt>('wrongProperty');
+      pathRef<PokemonInstance>('wrongProperty');
     });
   });
 
   describe('runtime behavior', () => {
     it('should preserve path string at runtime', () => {
       const originalPath = 'pokemon.skill.maxLevel';
-      const pathRef = PathReference.to<PokemonInstanceExt>(originalPath);
+      const pathRef = PathReference.to<PokemonInstance>(originalPath);
       expect(pathRef.path).toBe(originalPath);
     });
 
     it('should be distinguishable from regular strings', () => {
       const pathString = 'pokemon.frequency';
-      const pathRef = PathReference.to<PokemonInstanceExt>(pathString);
+      const pathRef = PathReference.to<PokemonInstance>(pathString);
 
       expect(pathRef.path).toBe(pathString);
       expect(pathRef).not.toBe(pathString);
@@ -161,7 +161,7 @@ describe('PathReference', () => {
       ] as const;
 
       complexPaths.forEach((path) => {
-        const pathRef = PathReference.to<PokemonInstanceExt>(path);
+        const pathRef = PathReference.to<PokemonInstance>(path);
         expect(pathRef.path).toBe(path);
         expect(isPathReference(pathRef)).toBe(true);
       });
@@ -171,7 +171,7 @@ describe('PathReference', () => {
   describe('usage in conditions', () => {
     it('should work in modifier conditions for cross-property comparisons', () => {
       // Example: skillLevel < pokemon.skill.maxLevel
-      const conditionValue = PathReference.to<PokemonInstanceExt>('pokemon.skill.maxLevel');
+      const conditionValue = PathReference.to<PokemonInstance>('pokemon.skill.maxLevel');
 
       expect(conditionValue.path).toBe('pokemon.skill.maxLevel');
       expect(isPathReference(conditionValue)).toBe(true);
@@ -182,7 +182,7 @@ describe('PathReference', () => {
 
     it('should enable dynamic value comparisons', () => {
       // Example: frequency < berry.strength (if such properties existed)
-      const dynamicValue = PathReference.to<PokemonInstanceExt>('pokemon.ingredientPercentage');
+      const dynamicValue = PathReference.to<PokemonInstance>('pokemon.ingredientPercentage');
 
       expect(dynamicValue.path).toBe('pokemon.ingredientPercentage');
       expect(isPathReference(dynamicValue)).toBe(true);
@@ -192,8 +192,8 @@ describe('PathReference', () => {
   describe('integration with existing types', () => {
     it('should integrate with PathKeys type', () => {
       // The fact that these compile shows integration with PathKeys<T>
-      const pokemonPathRef = PathReference.to<PokemonInstanceExt>('name');
-      const instancePathRef = PathReference.to<PokemonInstanceExt>('skillLevel');
+      const pokemonPathRef = PathReference.to<PokemonInstance>('name');
+      const instancePathRef = PathReference.to<PokemonInstance>('skillLevel');
 
       expect(pokemonPathRef.path).toBe('name');
       expect(instancePathRef.path).toBe('skillLevel');
@@ -201,9 +201,9 @@ describe('PathReference', () => {
 
     it('should support paths that work with PathValue type', () => {
       // These paths should be compatible with PathValue<T, P>
-      const stringPath = PathReference.to<PokemonInstanceExt>('pokemon.name'); // PathValue<PokemonInstanceExt, 'pokemon.name'> = string
-      const numberPath = PathReference.to<PokemonInstanceExt>('pokemon.frequency'); // PathValue<PokemonInstanceExt, 'pokemon.frequency'> = number
-      const nestedPath = PathReference.to<PokemonInstanceExt>('pokemon.berry.name'); // PathValue<PokemonInstanceExt, 'pokemon.berry.name'> = string
+      const stringPath = PathReference.to<PokemonInstance>('pokemon.name'); // PathValue<PokemonInstance, 'pokemon.name'> = string
+      const numberPath = PathReference.to<PokemonInstance>('pokemon.frequency'); // PathValue<PokemonInstance, 'pokemon.frequency'> = number
+      const nestedPath = PathReference.to<PokemonInstance>('pokemon.berry.name'); // PathValue<PokemonInstance, 'pokemon.berry.name'> = string
 
       expect(stringPath.path).toBe('pokemon.name');
       expect(numberPath.path).toBe('pokemon.frequency');

--- a/common/src/types/modifier/path-reference.ts
+++ b/common/src/types/modifier/path-reference.ts
@@ -5,7 +5,7 @@ import type { ModifierTargetType } from './target-types';
  * Wrapper type to explicitly mark a value as a path reference
  * This allows us to distinguish between literal values and path references at runtime
  *
- * @template T - The target type (Pokemon | PokemonInstanceExt) for type-safe path validation
+ * @template T - The target type (Pokemon | PokemonInstance) for type-safe path validation
  */
 export class PathReference<T extends ModifierTargetType = ModifierTargetType> {
   constructor(public readonly path: PathKeys<T>) {}

--- a/common/src/types/modifier/target-types.test.ts
+++ b/common/src/types/modifier/target-types.test.ts
@@ -1,32 +1,32 @@
 import { describe, expect, it } from 'vitest';
+import { pokemonInstance } from '../../vitest/mocks';
 import { memberStrength } from '../../vitest/mocks/events/mock-member-strength';
-import { pokemonInstanceExt } from '../../vitest/mocks/pokemon/mock-pokemon-instance';
 import type { ModifierTargetType, ModifierTargetTypeDTO, TargetTypeMap } from './target-types';
 
 describe('TargetTypeMap', () => {
   it('should map the correct type', () => {
-    const pokemonInstance: TargetTypeMap['PokemonInstance'] = pokemonInstanceExt();
+    const monInstance: TargetTypeMap['PokemonInstanceDto'] = pokemonInstance();
 
     // @ts-expect-error - invalid property, asserts that we indeed get a type-safe Pokemon object
-    pokemonInstance.invalid;
+    monInstance.invalid;
 
     // Check that we get a proper Pokemon object with expected properties
-    expect(typeof pokemonInstance).toBe('object');
-    expect(typeof pokemonInstance.name).toBe('string');
-    expect(typeof pokemonInstance.pokemon.displayName).toBe('string');
-    expect(typeof pokemonInstance.pokemon.pokedexNumber).toBe('number');
-    expect(typeof pokemonInstance.pokemon.specialty).toBe('string');
-    expect(typeof pokemonInstance.pokemon.frequency).toBe('number');
+    expect(typeof monInstance).toBe('object');
+    expect(typeof monInstance.name).toBe('string');
+    expect(typeof monInstance.pokemon.displayName).toBe('string');
+    expect(typeof monInstance.pokemon.pokedexNumber).toBe('number');
+    expect(typeof monInstance.pokemon.specialty).toBe('string');
+    expect(typeof monInstance.pokemon.frequency).toBe('number');
   });
 });
 
 describe('ModifierTargetType', () => {
   it('should be a union of all target types', () => {
-    const pokemonInstance: ModifierTargetType = pokemonInstanceExt();
+    const monInstance: ModifierTargetType = pokemonInstance();
     const strength: ModifierTargetType = memberStrength();
 
-    // @ts-expect-error - invalid property, asserts that we indeed get a type-safe PokemonInstanceExt object
-    pokemonInstance.invalid;
+    // @ts-expect-error - invalid property, asserts that we indeed get a type-safe PokemonInstance object
+    monInstance.invalid;
     // @ts-expect-error - invalid property, asserts that we indeed get a type-safe MemberStrength object
     strength.invalid;
 
@@ -34,21 +34,21 @@ describe('ModifierTargetType', () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const invalid: ModifierTargetType = 'not a valid target type';
 
-    expect(typeof pokemonInstance).toBe('object');
+    expect(typeof monInstance).toBe('object');
     expect(typeof strength).toBe('object');
   });
 });
 
 describe('ModifierTargetTypeDTO', () => {
   it('should be a union of all target types', () => {
-    const pokemonInstance: ModifierTargetTypeDTO = 'PokemonInstance';
-    const memberStrength: ModifierTargetTypeDTO = 'MemberStrength';
+    const pokemonInstance: ModifierTargetTypeDTO = 'PokemonInstanceDto';
+    const memberStrength: ModifierTargetTypeDTO = 'MemberStrengthDto';
 
     // @ts-expect-error - invalid target type
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const invalid: ModifierTargetTypeDTO = 'not a valid target type';
 
-    expect(pokemonInstance).toBe('PokemonInstance');
-    expect(memberStrength).toBe('MemberStrength');
+    expect(pokemonInstance).toBe('PokemonInstanceDto');
+    expect(memberStrength).toBe('MemberStrengthDto');
   });
 });

--- a/common/src/types/modifier/target-types.ts
+++ b/common/src/types/modifier/target-types.ts
@@ -1,8 +1,8 @@
-import type { PokemonInstanceExt } from '../instance';
-import type { MemberStrength, TeamMemberExt } from '../team';
+import type { PokemonInstance } from '../instance';
+import type { MemberStrength, TeamMember } from '../team';
 
-export type ModifierTargetTypeDTO = 'PokemonInstance' | 'MemberStrength' | 'TeamMember';
-export type ModifierTargetType = PokemonInstanceExt | MemberStrength | TeamMemberExt;
+export type ModifierTargetTypeDTO = 'PokemonInstanceDto' | 'MemberStrengthDto' | 'TeamMemberDto';
+export type ModifierTargetType = PokemonInstance | MemberStrength | TeamMember;
 
 /**
  * Used for mapping API strings to actual types
@@ -13,12 +13,12 @@ export type ModifierTargetType = PokemonInstanceExt | MemberStrength | TeamMembe
  * 3. Add the mapping entry here
  *
  * Example for adding a new "Item" type:
- * - ModifierTargetTypeDTO = 'Pokemon' | 'PokemonInstanceExt' | 'Item'
- * - ModifierTargetType = Pokemon | PokemonInstanceExt | Item
- * - TargetTypeMap = { Pokemon: Pokemon, PokemonInstanceExt: PokemonInstanceExt, Item: Item } *
+ * - ModifierTargetTypeDTO = 'PokemonDto' | 'PokemonInstanceDto' | 'ItemDto'
+ * - ModifierTargetType = Pokemon | PokemonInstance | Item
+ * - TargetTypeMap = { PokemonDto: Pokemon, PokemonInstanceDto: PokemonInstance, ItemDto: Item } *
  */
 export type TargetTypeMap = {
-  PokemonInstance: PokemonInstanceExt;
-  MemberStrength: MemberStrength;
-  TeamMember: TeamMemberExt;
+  PokemonInstanceDto: PokemonInstance;
+  MemberStrengthDto: MemberStrength;
+  TeamMemberDto: TeamMember;
 };

--- a/common/src/types/optimal/optimal.ts
+++ b/common/src/types/optimal/optimal.ts
@@ -1,5 +1,5 @@
 import { CarrySizeUtils } from '../../utils/carry-size-utils/carry-size-utils';
-import type { SubskillInstanceExt } from '../instance/subskill-instance';
+import type { SubskillInstance } from '../instance/subskill-instance';
 import type { Nature } from '../nature/nature';
 import { ADAMANT, CAREFUL, QUIET } from '../nature/nature';
 import type { Pokemon } from '../pokemon/pokemon';
@@ -14,10 +14,10 @@ import {
   SKILL_TRIGGER_M,
   SKILL_TRIGGER_S
 } from '../subskill/subskills';
-import type { TeamMemberSettingsExt } from '../team';
+import type { TeamMemberSettings } from '../team';
 
 export interface Optimal {
-  subskills: SubskillInstanceExt[];
+  subskills: SubskillInstance[];
   nature: Nature;
   carrySize: number;
   skillLevel: number;
@@ -75,14 +75,14 @@ class OptimalImpl {
 
   /**
    * Filters subskills on level
-   * @returns {TeamMemberSettingsExt}
+   * @returns {TeamMemberSettings}
    */
   public toMemberSettings(params: {
     stats: Optimal;
     level: number;
     externalId: string;
     sneakySnacking: boolean;
-  }): TeamMemberSettingsExt {
+  }): TeamMemberSettings {
     const { stats, level, externalId, sneakySnacking } = params;
 
     const subskills = new Set<string>();

--- a/common/src/types/solve/solve-ingredient.ts
+++ b/common/src/types/solve/solve-ingredient.ts
@@ -1,8 +1,8 @@
 import type { TeamMemberWithProduce } from '../../types/team/member';
-import type { SolveSettings } from '../../types/team/team';
+import type { SolveSettingsDto } from '../../types/team/team';
 
 export interface SolveIngredientRequest {
-  settings: SolveSettings;
+  settings: SolveSettingsDto;
 }
 
 export interface SolveIngredientResponse {

--- a/common/src/types/solve/solve-recipe.ts
+++ b/common/src/types/solve/solve-recipe.ts
@@ -1,10 +1,10 @@
 import type { IngredientSet } from '../../types/ingredient/ingredient';
-import type { TeamMember } from '../../types/team/member';
-import type { SolveSettings, TeamSolution } from '../../types/team/team';
+import type { TeamMemberDto } from '../../types/team/member';
+import type { SolveSettingsDto, TeamSolution } from '../../types/team/team';
 
 export interface SolveRecipeRequest {
-  settings: SolveSettings;
-  includedMembers?: TeamMember[];
+  settings: SolveSettingsDto;
+  includedMembers?: TeamMemberDto[];
   maxTeamSize?: number;
 }
 

--- a/common/src/types/team/member.ts
+++ b/common/src/types/team/member.ts
@@ -2,7 +2,7 @@ import type { IngredientSet } from '../ingredient/ingredient';
 import type { Nature } from '../nature/nature';
 import type { PokemonWithIngredients, PokemonWithIngredientsIndexed } from '../pokemon/pokemon';
 
-export interface TeamMemberSettings {
+export interface TeamMemberSettingsDto {
   level: number;
   nature: string;
   subskills: string[];
@@ -12,7 +12,7 @@ export interface TeamMemberSettings {
   externalId: string;
   sneakySnacking: boolean;
 }
-export interface TeamMemberSettingsExt {
+export interface TeamMemberSettings {
   level: number;
   nature: Nature;
   subskills: Set<string>;
@@ -23,17 +23,17 @@ export interface TeamMemberSettingsExt {
   sneakySnacking: boolean;
 }
 
-export interface TeamMember {
+export interface TeamMemberDto {
   pokemonWithIngredients: PokemonWithIngredientsIndexed;
+  settings: TeamMemberSettingsDto;
+}
+export interface TeamMember {
+  pokemonWithIngredients: PokemonWithIngredients;
   settings: TeamMemberSettings;
 }
-export interface TeamMemberExt {
-  pokemonWithIngredients: PokemonWithIngredients;
-  settings: TeamMemberSettingsExt;
-}
-export type TeamMemberSettingsResult = Omit<TeamMemberSettingsExt, 'subskills'> & { subskills: string[] };
+export type TeamMemberSettingsResult = Omit<TeamMemberSettings, 'subskills'> & { subskills: string[] };
 
 export interface TeamMemberWithProduce {
-  member: Omit<TeamMemberExt, 'settings'> & { settings: TeamMemberSettingsResult };
+  member: Omit<TeamMember, 'settings'> & { settings: TeamMemberSettingsResult };
   producedIngredients: IngredientSet[];
 }

--- a/common/src/types/team/team-calculate.ts
+++ b/common/src/types/team/team-calculate.ts
@@ -4,25 +4,25 @@ import type {
   IngredientSet,
   MainskillUnit,
   MealTimes,
-  PokemonInstance,
+  PokemonInstanceDto,
   PokemonWithIngredientsIndexed,
-  TeamMemberExt,
-  TeamSettings
+  TeamMember,
+  TeamSettingsDto
 } from '..';
 import type { Produce } from '../production';
 import type { Recipe } from '../recipe/recipe';
 
-export interface PokemonInstanceIdentity extends PokemonInstance {
+export interface PokemonInstanceIdentity extends PokemonInstanceDto {
   externalId: string;
 }
 
 export interface CalculateTeamRequest {
-  settings: TeamSettings;
+  settings: TeamSettingsDto;
   members: PokemonInstanceIdentity[];
 }
 
 export interface CalculateIvRequest {
-  settings: TeamSettings;
+  settings: TeamSettingsDto;
   members: PokemonInstanceIdentity[];
   variants: PokemonInstanceIdentity[];
 }
@@ -157,5 +157,5 @@ export interface SimpleTeamResult {
   critMultiplier: number;
   averageWeekdayPotSize: number;
   ingredientPercentage: number;
-  member: TeamMemberExt;
+  member: TeamMember;
 }

--- a/common/src/types/team/team.ts
+++ b/common/src/types/team/team.ts
@@ -4,14 +4,14 @@ import type { Time } from '../time/time';
 import type { TeamMemberWithProduce } from './member';
 import type { CalculateTeamResponse } from './team-calculate';
 
-export interface TeamSettings {
+export interface TeamSettingsDto {
   camp: boolean;
   bedtime: string;
   wakeup: string;
   island: IslandInstanceDto;
   stockpiledIngredients?: IngredientSetSimple[];
 }
-export interface TeamSettingsExt {
+export interface TeamSettings {
   camp: boolean;
   bedtime: Time;
   wakeup: Time;
@@ -28,9 +28,9 @@ export interface TeamSolution {
 
 export type TeamResults = CalculateTeamResponse;
 
-export interface SolveSettings extends TeamSettings {
+export interface SolveSettingsDto extends TeamSettingsDto {
   level: number;
 }
-export interface SolveSettingsExt extends TeamSettingsExt {
+export interface SolveSettings extends TeamSettings {
   level: number;
 }

--- a/common/src/types/tierlist/pokemon-with-tiering.ts
+++ b/common/src/types/tierlist/pokemon-with-tiering.ts
@@ -1,7 +1,7 @@
 import type { IngredientSetSimple } from '../ingredient';
 import type { PokemonWithIngredientsSimple } from '../pokemon/pokemon';
 import type { Recipe } from '../recipe/recipe';
-import type { TeamMemberSettings } from '../team';
+import type { TeamMemberSettingsDto } from '../team';
 import type { Tier } from './tier';
 
 export interface TeamMemberProduction extends PokemonWithIngredientsSimple {
@@ -29,7 +29,7 @@ export interface PokemonWithRecipeContributions {
     totalIngredients: Float32Array;
     critMultiplier: number;
     averageWeekdayPotSize: number;
-    settings: TeamMemberSettings;
+    settings: TeamMemberSettingsDto;
   };
   contributions: RecipeContributionSimple[];
 }

--- a/common/src/utils/rp-utils/rp.ts
+++ b/common/src/utils/rp-utils/rp.ts
@@ -15,7 +15,7 @@
  */
 
 import type { IngredientSet } from '../../types/ingredient';
-import type { PokemonInstanceExt } from '../../types/instance/pokemon-instance';
+import type { PokemonInstance } from '../../types/instance/pokemon-instance';
 import type { Nature } from '../../types/nature/nature';
 import type { Pokemon } from '../../types/pokemon';
 import {
@@ -39,7 +39,7 @@ import {
   calculateSkillPercentage
 } from '../../utils/stat-utils';
 
-export type PokemonInstanceWithoutRP = Omit<PokemonInstanceExt, 'rp' | 'carrySize'>;
+export type PokemonInstanceWithoutRP = Omit<PokemonInstance, 'rp' | 'carrySize'>;
 
 export class RP {
   private pokemon: Pokemon;

--- a/common/src/utils/subskill-utils/subskill-utils.test.ts
+++ b/common/src/utils/subskill-utils/subskill-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { PokemonInstanceExt } from '../../types/instance/pokemon-instance';
+import type { PokemonInstance } from '../../types/instance/pokemon-instance';
 import type { Subskill } from '../../types/subskill/subskill';
 import {
   DREAM_SHARD_BONUS,
@@ -131,7 +131,7 @@ describe('filterMembersWithSubskill', () => {
       subskills: [{ subskill: { name: 'Other Subskill' } as Subskill, level: 10 }],
       level: 10
     }
-  ] as PokemonInstanceExt[];
+  ] as PokemonInstance[];
 
   it('shall return members with the specified subskill and level less than or equal to member level', () => {
     expect(filterMembersWithSubskill(members, subskill)).toEqual([
@@ -158,7 +158,7 @@ describe('filterMembersWithSubskill', () => {
         subskills: [{ subskill: highLevelSubskill, level: 20 }],
         level: 10
       }
-    ] as PokemonInstanceExt[];
+    ] as PokemonInstance[];
     expect(filterMembersWithSubskill(highLevelMembers, highLevelSubskill)).toEqual([]);
   });
 });

--- a/common/src/utils/subskill-utils/subskill-utils.ts
+++ b/common/src/utils/subskill-utils/subskill-utils.ts
@@ -1,4 +1,4 @@
-import type { PokemonInstanceExt, Subskill } from '../../types';
+import type { PokemonInstance, Subskill } from '../../types';
 import { SUBSKILLS } from '../../types/subskill/subskills';
 
 export function getSubskillNames() {
@@ -28,7 +28,7 @@ export function limitSubSkillsToLevel(subskills: Set<string>, level: number): Se
   return result;
 }
 
-export function filterMembersWithSubskill(members: PokemonInstanceExt[], subskill: Subskill) {
+export function filterMembersWithSubskill(members: PokemonInstance[], subskill: Subskill) {
   return members.filter((member) =>
     member.subskills.some((s) => s.subskill.name === subskill.name && s.level <= member.level)
   );

--- a/common/src/vitest/mocks/events/mock-event.ts
+++ b/common/src/vitest/mocks/events/mock-event.ts
@@ -7,7 +7,7 @@ export function event(attrs?: Partial<Event>): Event {
     description: 'Test event description',
     modifiers: [
       {
-        type: 'PokemonInstance',
+        type: 'PokemonInstanceDto',
         leftValue: 'pokemon.frequency',
         operation: '*',
         rightValue: 0.9

--- a/common/src/vitest/mocks/pokemon/mock-pokemon-instance.ts
+++ b/common/src/vitest/mocks/pokemon/mock-pokemon-instance.ts
@@ -1,8 +1,8 @@
-import type { PokemonInstance, PokemonInstanceExt } from '../../../types/instance';
+import type { PokemonInstance, PokemonInstanceDto } from '../../../types/instance';
 import { BASHFUL } from '../../../types/nature';
 import { mockPokemon } from './mock-pokemon';
 
-export function pokemonInstance(attrs?: Partial<PokemonInstance>): PokemonInstance {
+export function pokemonInstanceDto(attrs?: Partial<PokemonInstanceDto>): PokemonInstanceDto {
   return {
     pokemon: mockPokemon().name,
     level: 1,
@@ -17,9 +17,9 @@ export function pokemonInstance(attrs?: Partial<PokemonInstance>): PokemonInstan
   };
 }
 
-export function pokemonInstanceExt(attrs?: Partial<PokemonInstanceExt>): PokemonInstanceExt {
+export function pokemonInstance(attrs?: Partial<PokemonInstance>): PokemonInstance {
   return {
-    ...pokemonInstance(),
+    ...pokemonInstanceDto(),
     rp: 0,
     pokemon: mockPokemon(),
     nature: BASHFUL,

--- a/common/src/vitest/mocks/team/mock-team-member-ext.ts
+++ b/common/src/vitest/mocks/team/mock-team-member-ext.ts
@@ -1,11 +1,11 @@
-import type { TeamMemberExt } from '../../../types/team/member';
+import type { TeamMember } from '../../../types/team/member';
 import { pokemonWithIngredients } from '../pokemon/mock-pokemon-with-ingredients';
-import { teamMemberSettingsExt } from './mock-team-member-settings-ext';
+import { teamMemberSettings } from './mock-team-member-settings-ext';
 
-export function teamMemberExt(attrs?: Partial<TeamMemberExt>): TeamMemberExt {
+export function teamMember(attrs?: Partial<TeamMember>): TeamMember {
   return {
     pokemonWithIngredients: pokemonWithIngredients(),
-    settings: teamMemberSettingsExt(),
+    settings: teamMemberSettings(),
     ...attrs
   };
 }

--- a/common/src/vitest/mocks/team/mock-team-member-settings-ext.ts
+++ b/common/src/vitest/mocks/team/mock-team-member-settings-ext.ts
@@ -1,7 +1,7 @@
 import { BASHFUL } from '../../../types/nature';
-import type { TeamMemberSettingsExt } from '../../../types/team/member';
+import type { TeamMemberSettings } from '../../../types/team/member';
 
-export function teamMemberSettingsExt(attrs?: Partial<TeamMemberSettingsExt>): TeamMemberSettingsExt {
+export function teamMemberSettings(attrs?: Partial<TeamMemberSettings>): TeamMemberSettings {
   return {
     carrySize: 1,
     externalId: 'mock id',

--- a/common/src/vitest/mocks/team/mock-team-settings.ts
+++ b/common/src/vitest/mocks/team/mock-team-settings.ts
@@ -1,9 +1,9 @@
-import type { TeamSettings, TeamSettingsExt } from '../../../types/team/team';
+import type { TeamSettings, TeamSettingsDto } from '../../../types/team/team';
 import { mockIngredientSetFloatIndexed } from '../ingredient/mock-ingredient-set';
 import { islandInstance } from '../island';
 import { bedtime, wakeup } from '../time';
 
-export function teamSettings(attrs?: Partial<TeamSettings>): TeamSettings {
+export function teamSettingsDto(attrs?: Partial<TeamSettingsDto>): TeamSettingsDto {
   return {
     camp: false,
     bedtime: '21:30',
@@ -14,7 +14,7 @@ export function teamSettings(attrs?: Partial<TeamSettings>): TeamSettings {
   };
 }
 
-export function teamSettingsExt(attrs?: Partial<TeamSettingsExt>): TeamSettingsExt {
+export function teamSettings(attrs?: Partial<TeamSettings>): TeamSettings {
   return {
     bedtime: bedtime(),
     wakeup: wakeup(),

--- a/frontend/src/components/calculator/results/member-results/island-impact/island-impact.test.ts
+++ b/frontend/src/components/calculator/results/member-results/island-impact/island-impact.test.ts
@@ -3,19 +3,19 @@ import { useUserStore } from '@/stores/user-store'
 import { mocks } from '@/vitest'
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { berry, commonMocks, type IslandInstance, type PokemonInstanceExt } from 'sleepapi-common'
+import { berry, commonMocks, type IslandInstance, type PokemonInstance } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 const expertIsland = (attrs?: Partial<Parameters<typeof commonMocks.expertModeSettings>[0]>): IslandInstance =>
   commonMocks.expertIslandInstance({ expertMode: commonMocks.expertModeSettings(attrs) })
 
-const mainFavoriteMember = (): PokemonInstanceExt =>
+const mainFavoriteMember = (): PokemonInstance =>
   mocks.createMockPokemon({ pokemon: commonMocks.mockPokemon({ berry: berry.BELUE }) })
 
-const subFavoriteMember = (): PokemonInstanceExt =>
+const subFavoriteMember = (): PokemonInstance =>
   mocks.createMockPokemon({ pokemon: commonMocks.mockPokemon({ berry: berry.GREPA }) })
 
-const notFavoredMember = (): PokemonInstanceExt =>
+const notFavoredMember = (): PokemonInstance =>
   mocks.createMockPokemon({ pokemon: commonMocks.mockPokemon({ berry: berry.CHERI }) })
 
 describe('IslandImpact', () => {

--- a/frontend/src/components/calculator/results/member-results/island-impact/island-impact.vue
+++ b/frontend/src/components/calculator/results/member-results/island-impact/island-impact.vue
@@ -47,7 +47,7 @@
 <script setup lang="ts">
 import { berryImage } from '@/services/utils/image-utils'
 import { useUserStore } from '@/stores/user-store'
-import { capitalize, hasSpecialty, type IslandInstance, type PokemonInstanceExt } from 'sleepapi-common'
+import { capitalize, hasSpecialty, type IslandInstance, type PokemonInstance } from 'sleepapi-common'
 import { computed } from 'vue'
 import {
   baseFavoriteBerryEffect,
@@ -61,7 +61,7 @@ import {
 } from './island-effects'
 
 const props = defineProps<{
-  member: PokemonInstanceExt
+  member: PokemonInstance
   island: IslandInstance
   effectiveSkillLevel: number
 }>()

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-berry.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-berry.test.ts
@@ -7,8 +7,8 @@ import { mount } from '@vue/test-utils'
 import { GENGAR, MathUtils, berry, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const baseProduction = mocks.createMockMemberProductionExt().production
-const mockMember = mocks.createMockMemberProductionExt({
+const baseProduction = mocks.createMockMemberWithProduction().production
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: GENGAR }),
   production: {
     ...baseProduction,

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-berry.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-berry.vue
@@ -30,7 +30,7 @@
 import { useBreakpoint } from '@/composables/use-breakpoint/use-breakpoint'
 import { berryImage } from '@/services/utils/image-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -38,7 +38,7 @@ export default defineComponent({
   name: 'MemberProductionBerry',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-header.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-header.test.ts
@@ -7,7 +7,7 @@ import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt()
+const mockMember = mocks.createMockMemberWithProduction()
 
 describe('MemberProductionHeader', () => {
   let wrapper: VueWrapper<InstanceType<typeof MemberProductionHeader>>

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-header.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-header.vue
@@ -21,7 +21,7 @@ import MemberProductionSkill from '@/components/calculator/results/member-result
 import { berryImage, mainskillImage } from '@/services/utils/image-utils'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -34,7 +34,7 @@ export default defineComponent({
   },
   props: {
     member: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-ingredient.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-ingredient.test.ts
@@ -5,7 +5,7 @@ import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt()
+const mockMember = mocks.createMockMemberWithProduction()
 
 describe('MemberProductionIngredient', () => {
   let wrapper: VueWrapper<InstanceType<typeof MemberProductionIngredient>>

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-ingredient.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-ingredient.vue
@@ -27,7 +27,7 @@
 <script lang="ts">
 import { useBreakpoint } from '@/composables/use-breakpoint/use-breakpoint'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils, type IngredientSet } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -35,7 +35,7 @@ export default defineComponent({
   name: 'MemberProductionIngredient',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/berry-burst-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/berry-burst-details.test.ts
@@ -6,10 +6,10 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { berry, BRAVIARY, compactNumber, MathUtils } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: BRAVIARY }),
   production: {
-    ...mocks.createMockMemberProductionExt().production,
+    ...mocks.createMockMemberWithProduction().production,
     produceFromSkill: {
       berries: [
         { amount: 100, berry: BRAVIARY.berry, level: 1 },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/berry-burst-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/berry-burst-details.vue
@@ -83,14 +83,14 @@
 import { berryImage, mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { BerryBurst, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/disguise-berry-burst-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/disguise-berry-burst-details.test.ts
@@ -6,10 +6,10 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { MIMIKYU, MathUtils, berry, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: MIMIKYU }),
   production: {
-    ...mocks.createMockMemberProductionExt().production,
+    ...mocks.createMockMemberWithProduction().production,
     produceFromSkill: {
       berries: [
         { amount: 100, berry: MIMIKYU.berry, level: 1 },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/disguise-berry-burst-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/disguise-berry-burst-details.vue
@@ -83,14 +83,14 @@
 import { berryImage, mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { BerryBurstDisguise, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/draco-meteor-berry-burst-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/draco-meteor-berry-burst-details.test.ts
@@ -19,7 +19,7 @@ import {
 } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: LATIOS, skillLevel: 6, level: 1 }),
   production: mocks.createMockMemberProduction({
     skillLevel: 6,

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/draco-meteor-berry-burst-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/berry-burst/draco-meteor-berry-burst-details.vue
@@ -84,14 +84,14 @@ import { berryImage, mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { BerryBurstDracoMeteor, compactNumber, MathUtils, uniqueMembersWithBerry } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-energy-s/charge-energy-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-energy-s/charge-energy-s-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { MathUtils, VICTREEBEL, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: VICTREEBEL })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-energy-s/charge-energy-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-energy-s/charge-energy-s-details.vue
@@ -51,14 +51,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { ChargeEnergyS, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-energy-s/moonlight-charge-energy-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-energy-s/moonlight-charge-energy-s-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { MathUtils, UMBREON, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: UMBREON })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-energy-s/moonlight-charge-energy-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-energy-s/moonlight-charge-energy-s-details.vue
@@ -66,14 +66,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { ChargeEnergySMoonlight, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-m/bad-dreams-charge-strength-m-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-m/bad-dreams-charge-strength-m-details.test.ts
@@ -1,5 +1,5 @@
 import MemberProductionSkill from '@/components/calculator/results/member-results/member-production-header/member-production-skill.vue'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { timeWindowFactor } from '@/types/time/time-window'
 import { mocks } from '@/vitest'
 import type { VueWrapper } from '@vue/test-utils'
@@ -8,7 +8,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { DARKRAI, MathUtils, compactNumber, type MemberSkillValue } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mockMember: MemberProductionExt = mocks.createMockMemberProductionExt({
+const mockMember: MemberWithProduction = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: DARKRAI })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-m/bad-dreams-charge-strength-m-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-m/bad-dreams-charge-strength-m-details.vue
@@ -68,14 +68,14 @@ import { mainskillImage } from '@/services/utils/image-utils'
 import { applyAreaBonus, skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { ChargeStrengthMBadDreams, compactNumber, localizeNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-m/charge-strength-m-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-m/charge-strength-m-details.test.ts
@@ -1,6 +1,6 @@
 import MemberProductionSkill from '@/components/calculator/results/member-results/member-production-header/member-production-skill.vue'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { timeWindowFactor } from '@/types/time/time-window'
 import { mocks } from '@/vitest'
 import type { VueWrapper } from '@vue/test-utils'
@@ -8,7 +8,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { ChargeStrengthM, ESPEON, MathUtils, compactNumber, localizeNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember: MemberProductionExt = mocks.createMockMemberProductionExt({
+const mockMember: MemberWithProduction = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: ESPEON })
 })
 describe('ChargeStrengthMDetails', () => {

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-m/charge-strength-m-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-m/charge-strength-m-details.vue
@@ -51,14 +51,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { applyAreaBonus, skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { ChargeStrengthM, compactNumber, localizeNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/charge-strength-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/charge-strength-s-details.test.ts
@@ -7,7 +7,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { ChargeStrengthS, MathUtils, RAICHU, compactNumber, localizeNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: RAICHU })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/charge-strength-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/charge-strength-s-details.vue
@@ -51,14 +51,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { applyAreaBonus, skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { ChargeStrengthS, compactNumber, localizeNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/charge-strength-s-range-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/charge-strength-s-range-details.test.ts
@@ -5,7 +5,7 @@ import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
 import { GOLDUCK, MathUtils, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: GOLDUCK })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/charge-strength-s-range-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/charge-strength-s-range-details.vue
@@ -51,14 +51,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { applyAreaBonus, skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { ChargeStrengthSRange, compactNumber, localizeNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/charge-strength-s-range-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/charge-strength-s-range-details.vue
@@ -58,14 +58,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { applyAreaBonus, skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { ChargeStrengthSRange, compactNumber, localizeNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/stockpile-charge-strength-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/stockpile-charge-strength-s-details.test.ts
@@ -7,7 +7,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { ChargeStrengthSStockpile, DRIFBLIM, MathUtils, compactNumber, localizeNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: DRIFBLIM })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/stockpile-charge-strength-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/charge-strength-s/stockpile-charge-strength-s-details.vue
@@ -51,14 +51,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { applyAreaBonus, skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { ChargeStrengthSStockpile, MathUtils, compactNumber, localizeNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/cooking-assist-s/bulk-up-cooking-assist-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/cooking-assist-s/bulk-up-cooking-assist-s-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { CookingAssistSBulkUp, HERACROSS, MathUtils, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: HERACROSS })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/cooking-assist-s/bulk-up-cooking-assist-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/cooking-assist-s/bulk-up-cooking-assist-s-details.vue
@@ -85,7 +85,7 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { CookingAssistSBulkUp, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -93,7 +93,7 @@ export default defineComponent({
   name: 'CookingAssistSBulkUpDetails',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/cooking-power-up-s/cooking-power-up-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/cooking-power-up-s/cooking-power-up-s-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { MAGNEZONE, MathUtils, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: MAGNEZONE })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/cooking-power-up-s/cooking-power-up-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/cooking-power-up-s/cooking-power-up-s-details.vue
@@ -63,14 +63,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { CookingPowerUpS, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/cooking-power-up-s/minus-cooking-power-up-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/cooking-power-up-s/minus-cooking-power-up-s-details.vue
@@ -68,7 +68,7 @@ import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { CookingPowerUpSMinus, MathUtils, compactNumber, isPlusOrMinus } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -76,7 +76,7 @@ export default defineComponent({
   name: 'CookingPowerUpSMinusDetails',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/aura-sphere-dream-shard-magnet-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/aura-sphere-dream-shard-magnet-s-details.vue
@@ -61,14 +61,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { DreamShardMagnetSAuraSphere, MathUtils, compactNumber, localizeNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/dream-shard-magnet-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/dream-shard-magnet-s-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { MathUtils, SWALOT, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: SWALOT })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/dream-shard-magnet-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/dream-shard-magnet-s-details.vue
@@ -51,14 +51,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { DreamShardMagnetS, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/dream-shard-magnet-s-range-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/dream-shard-magnet-s-range-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { MathUtils, PERSIAN, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: PERSIAN })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/dream-shard-magnet-s-range-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/dream-shard-magnet-s-range-details.vue
@@ -51,14 +51,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { DreamShardMagnetSRange, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/dream-shard-magnet-s-range-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/dream-shard-magnet-s/dream-shard-magnet-s-range-details.vue
@@ -58,14 +58,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { DreamShardMagnetSRange, MathUtils, compactNumber, localizeNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energizing-cheer-s/energizing-cheer-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energizing-cheer-s/energizing-cheer-s-details.test.ts
@@ -5,7 +5,7 @@ import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
 import { MathUtils, SLOWKING, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: SLOWKING })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energizing-cheer-s/energizing-cheer-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energizing-cheer-s/energizing-cheer-s-details.vue
@@ -51,14 +51,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { EnergizingCheerS, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energizing-cheer-s/heal-pulse-energizing-cheer-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energizing-cheer-s/heal-pulse-energizing-cheer-s-details.test.ts
@@ -15,7 +15,7 @@ import {
 import { beforeEach, describe, expect, it } from 'vitest'
 import HealPulseEnergizingCheerSDetails from './heal-pulse-energizing-cheer-s-details.vue'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({
     pokemon: commonMocks.mockPokemon({ skill: EnergizingCheerSHealPulse }),
     skillLevel: 6

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energizing-cheer-s/heal-pulse-energizing-cheer-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energizing-cheer-s/heal-pulse-energizing-cheer-s-details.vue
@@ -70,14 +70,14 @@ import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { EnergizingCheerSHealPulse, MathUtils, compactNumber, defaultZero } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energizing-cheer-s/nuzzle-energizing-cheer-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energizing-cheer-s/nuzzle-energizing-cheer-s-details.vue
@@ -51,14 +51,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { EnergizingCheerSNuzzle, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/berry-juice-energy-for-everyone-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/berry-juice-energy-for-everyone-s-details.test.ts
@@ -9,7 +9,7 @@ import { EnergyForEveryoneSBerryJuice, MathUtils, commonMocks, compactNumber } f
 import { beforeEach, describe, expect, it } from 'vitest'
 import BerryJuiceEnergyForEveryoneDetails from './berry-juice-energy-for-everyone-s-details.vue'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({
     pokemon: commonMocks.mockPokemon({ skill: EnergyForEveryoneSBerryJuice }),
     skillLevel: 6

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/berry-juice-energy-for-everyone-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/berry-juice-energy-for-everyone-s-details.vue
@@ -67,14 +67,14 @@
 import { berryImage, mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { EnergyForEveryoneSBerryJuice, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/energy-for-everyone-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/energy-for-everyone-s-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { MathUtils, SYLVEON, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: SYLVEON })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/energy-for-everyone-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/energy-for-everyone-s-details.vue
@@ -51,14 +51,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { EnergyForEveryoneS, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/lunar-blessing-energy-for-everyone-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/lunar-blessing-energy-for-everyone-s-details.test.ts
@@ -10,7 +10,7 @@ import { CRESSELIA, MathUtils, compactNumber } from 'sleepapi-common'
 import { beforeEach, describe, expect, it } from 'vitest'
 import LunarBlessingEnergyForEveryoneDetails from './lunar-blessing-energy-for-everyone-s-details.vue'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: CRESSELIA, skillLevel: 6, externalId: 'mockExternalId' })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/lunar-blessing-energy-for-everyone-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/energy-for-everyone-s/lunar-blessing-energy-for-everyone-s-details.vue
@@ -98,14 +98,14 @@ import { berryImage, mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { EnergyForEveryoneSLunarBlessing, MathUtils, compactNumber, uniqueMembersWithBerry } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/extra-helpful-s/extra-helpful-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/extra-helpful-s/extra-helpful-s-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { GALLADE, MathUtils, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: GALLADE })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/extra-helpful-s/extra-helpful-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/extra-helpful-s/extra-helpful-s-details.vue
@@ -50,14 +50,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { ExtraHelpfulS, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/helper-boost/helper-boost-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/helper-boost/helper-boost-details.test.ts
@@ -9,7 +9,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { ENTEI, MathUtils, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: ENTEI, skillLevel: 6 })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/helper-boost/helper-boost-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/helper-boost/helper-boost-details.vue
@@ -55,14 +55,14 @@ import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { compactNumber, HelperBoost, MathUtils, uniqueMembersWithBerry } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-draw-s/hyper-cutter-ingredient-draw-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-draw-s/hyper-cutter-ingredient-draw-s-details.test.ts
@@ -6,7 +6,7 @@ import { MathUtils, VAPOREON } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import HyperCutterIngredientDrawSDetails from './hyper-cutter-ingredient-draw-s-details.vue'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: VAPOREON })
 })
 
@@ -91,7 +91,7 @@ describe('HyperCutterIngredientDrawSDetails', () => {
   })
 
   it('displays ingredient images when ingredient data is present', () => {
-    const mockWithIngredients = mocks.createMockMemberProductionExt({
+    const mockWithIngredients = mocks.createMockMemberWithProduction({
       member: mocks.createMockPokemon({ pokemon: VAPOREON }),
       production: {
         ...mocks.createMockMemberProduction(),

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-draw-s/hyper-cutter-ingredient-draw-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-draw-s/hyper-cutter-ingredient-draw-s-details.vue
@@ -66,7 +66,7 @@
 import { ingredientImage, mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { IngredientDrawSHyperCutter, MathUtils } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -74,7 +74,7 @@ export default defineComponent({
   name: 'IngredientDrawSHyperCutterDetails',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-draw-s/ingredient-draw-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-draw-s/ingredient-draw-s-details.vue
@@ -66,7 +66,7 @@
 import { ingredientImage, mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -74,7 +74,7 @@ export default defineComponent({
   name: 'IngredientDrawSDetails',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-draw-s/super-luck-ingredient-draw-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-draw-s/super-luck-ingredient-draw-s-details.test.ts
@@ -6,7 +6,7 @@ import { MathUtils, VAPOREON } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import SuperLuckIngredientDrawSDetails from './super-luck-ingredient-draw-s-details.vue'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: VAPOREON })
 })
 
@@ -91,7 +91,7 @@ describe('SuperLuckIngredientDrawSDetails', () => {
   })
 
   it('displays ingredient images when ingredient data is present', () => {
-    const mockWithIngredients = mocks.createMockMemberProductionExt({
+    const mockWithIngredients = mocks.createMockMemberWithProduction({
       member: mocks.createMockPokemon({ pokemon: VAPOREON }),
       production: {
         ...mocks.createMockMemberProduction(),

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-draw-s/super-luck-ingredient-draw-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-draw-s/super-luck-ingredient-draw-s-details.vue
@@ -74,7 +74,7 @@
 import { ingredientImage, mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { IngredientDrawSSuperLuck, MathUtils, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -82,7 +82,7 @@ export default defineComponent({
   name: 'IngredientDrawSSuperLuckDetails',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-magnet-s/ingredient-magnet-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-magnet-s/ingredient-magnet-s-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { MathUtils, VAPOREON, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: VAPOREON })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-magnet-s/ingredient-magnet-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-magnet-s/ingredient-magnet-s-details.vue
@@ -66,7 +66,7 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { compactNumber, ingredient, IngredientMagnetS } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -74,7 +74,7 @@ export default defineComponent({
   name: 'IngredientMagnetSDetails',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-magnet-s/plus-ingredient-magnet-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-magnet-s/plus-ingredient-magnet-s-details.vue
@@ -79,7 +79,7 @@ import { ingredientImage, mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils, compactNumber, ingredient, isPlusOrMinus } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -87,7 +87,7 @@ export default defineComponent({
   name: 'IngredientMagnetSPlusDetails',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-magnet-s/present-ingredient-magnet-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-magnet-s/present-ingredient-magnet-s-details.test.ts
@@ -1,13 +1,13 @@
 import MemberProductionSkill from '@/components/calculator/results/member-results/member-production-header/member-production-skill.vue'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { mocks } from '@/vitest'
 import type { VueWrapper } from '@vue/test-utils'
 import { flushPromises, mount } from '@vue/test-utils'
 import { DELIBIRD, MathUtils, compactNumber, type MemberSkillValue } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember: MemberProductionExt = mocks.createMockMemberProductionExt({
+const mockMember: MemberWithProduction = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: DELIBIRD })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-magnet-s/present-ingredient-magnet-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/ingredient-magnet-s/present-ingredient-magnet-s-details.vue
@@ -76,7 +76,7 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { IngredientMagnetSPresent, compactNumber, ingredient } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
@@ -84,7 +84,7 @@ export default defineComponent({
   name: 'PresentIngredientMagnetSDetails',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/metronome/metronome-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/metronome/metronome-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { MathUtils, TOGEKISS } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: TOGEKISS })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/metronome/metronome-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/metronome/metronome-details.vue
@@ -44,14 +44,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/skill-copy/mimic-skill-copy-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/skill-copy/mimic-skill-copy-details.vue
@@ -44,14 +44,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/skill-copy/transform-skill-copy-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/skill-copy/transform-skill-copy-details.vue
@@ -44,14 +44,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/tasty-chance-s/tasty-chance-s-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/tasty-chance-s/tasty-chance-s-details.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { MathUtils, TastyChanceS, commonMocks, compactNumber } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: commonMocks.mockPokemon({ skill: TastyChanceS }) })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/tasty-chance-s/tasty-chance-s-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/tasty-chance-s/tasty-chance-s-details.vue
@@ -56,14 +56,14 @@
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils, TastyChanceS, compactNumber } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/versatile/versatile-details.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/versatile/versatile-details.test.ts
@@ -1,12 +1,12 @@
 import MemberProductionSkill from '@/components/calculator/results/member-results/member-production-header/member-production-skill.vue'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { mocks } from '@/vitest'
 import type { VueWrapper } from '@vue/test-utils'
 import { flushPromises, mount } from '@vue/test-utils'
 import { commonMocks, Versatile } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember: MemberProductionExt = mocks.createMockMemberProductionExt({
+const mockMember: MemberWithProduction = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: commonMocks.mockPokemon({ skill: Versatile }) })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/versatile/versatile-details.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill-details/versatile/versatile-details.vue
@@ -35,13 +35,13 @@
 <script lang="ts">
 import { mainskillImage } from '@/services/utils/image-utils'
 import { skillLevelBadgeText } from '@/services/utils/skill-display-utils'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill.test.ts
@@ -6,7 +6,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { TYRANITAR, VAPOREON } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-const mockMember = mocks.createMockMemberProductionExt({
+const mockMember = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({ pokemon: TYRANITAR })
 })
 

--- a/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill.vue
+++ b/frontend/src/components/calculator/results/member-results/member-production-header/member-production-skill.vue
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { mainskillImage } from '@/services/utils/image-utils'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils, ModifiedMainskill } from 'sleepapi-common'
 import { defineAsyncComponent, defineComponent, type PropType } from 'vue'
 
@@ -21,7 +21,7 @@ export default defineComponent({
   name: 'MemberProductionSkill',
   props: {
     memberWithProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/member-results.vue
+++ b/frontend/src/components/calculator/results/member-results/member-results.vue
@@ -199,13 +199,13 @@ import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
 import { useUserStore } from '@/stores/user-store'
 import { UnexpectedError } from '@/types/errors/unexpected-error'
-import type { MemberProductionExt, PerformanceDetails } from '@/types/member/instanced'
+import type { MemberWithProduction, PerformanceDetails } from '@/types/member/instanced'
 import {
   MathUtils,
   type MemberProductionBase,
-  type PokemonInstanceExt,
+  type PokemonInstance,
   subskill,
-  type SubskillInstanceExt
+  type SubskillInstance
 } from 'sleepapi-common'
 import { computed, defineComponent, nextTick, onBeforeUnmount, onMounted, ref, watchEffect } from 'vue'
 import { useTheme } from 'vuetify'
@@ -230,7 +230,7 @@ export default defineComponent({
     const { isMobile } = useBreakpoint()
 
     const subskillMenuOpen = ref(false)
-    const editingMember = ref<MemberProductionExt | null | undefined>(null)
+    const editingMember = ref<MemberWithProduction | null | undefined>(null)
 
     const currentMember = computed(() => {
       return teamStore.getCurrentMember
@@ -300,18 +300,18 @@ export default defineComponent({
       window.removeEventListener('resize', updateClipPath)
     })
 
-    const openSubskillMenu = (memberWithProd: MemberProductionExt) => {
+    const openSubskillMenu = (memberWithProd: MemberWithProduction) => {
       editingMember.value = memberWithProd
       subskillMenuOpen.value = true
     }
 
-    const handleUpdateSubskills = (updatedSubskills: SubskillInstanceExt[]) => {
+    const handleUpdateSubskills = (updatedSubskills: SubskillInstance[]) => {
       if (!editingMember.value || !editingMember.value.member) {
         console.error('Error: editingMember is not defined when updating subskills.')
         return
       }
 
-      const updatedMember: PokemonInstanceExt = {
+      const updatedMember: PokemonInstance = {
         ...editingMember.value.member,
         subskills: updatedSubskills
       }
@@ -351,7 +351,7 @@ export default defineComponent({
     }
   },
   computed: {
-    membersWithProduction(): (MemberProductionExt | undefined)[] {
+    membersWithProduction(): (MemberWithProduction | undefined)[] {
       const result = []
       for (const member of this.teamStore.getCurrentMembersWithProduction) {
         result.push(member)

--- a/frontend/src/components/calculator/results/member-results/member-stats/member-stats.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-stats/member-stats.test.ts
@@ -1,13 +1,13 @@
 import MemberStats from '@/components/calculator/results/member-results/member-stats/member-stats.vue'
 import SkillDistribution from '@/components/calculator/results/member-results/member-stats/skill-distribution.vue'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { mocks } from '@/vitest'
 import { mount } from '@vue/test-utils'
 import { commonMocks, subskill } from 'sleepapi-common'
 import { describe, expect, it, vi } from 'vitest'
 
 // Create a dummy production with additional properties: level, ingredient list, and dayPeriod values
-const pokemonProduction: MemberProductionExt = mocks.createMockMemberProductionExt({
+const pokemonProduction: MemberWithProduction = mocks.createMockMemberWithProduction({
   member: mocks.createMockPokemon({
     rp: 100,
     level: 5,
@@ -107,7 +107,7 @@ describe('MemberStats.vue', () => {
 
   it('does not render spilled ingredients section when none exist', () => {
     // Create a production with no spilled ingredients
-    const productionWithoutSpilled: MemberProductionExt = mocks.createMockMemberProductionExt({
+    const productionWithoutSpilled: MemberWithProduction = mocks.createMockMemberWithProduction({
       member: mocks.createMockPokemon({
         rp: 100,
         level: 5,
@@ -145,7 +145,7 @@ describe('MemberStats.vue', () => {
   })
 
   it('renders subskill carry bonus when greater than 0', () => {
-    const productionWithSubskills: MemberProductionExt = mocks.createMockMemberProductionExt({
+    const productionWithSubskills: MemberWithProduction = mocks.createMockMemberWithProduction({
       member: mocks.createMockPokemon({
         subskills: [
           { subskill: subskill.INVENTORY_S, level: 10 },
@@ -161,7 +161,7 @@ describe('MemberStats.vue', () => {
   })
 
   it('renders ribbon carry bonus when greater than 0', () => {
-    const productionWithRibbon: MemberProductionExt = mocks.createMockMemberProductionExt({
+    const productionWithRibbon: MemberWithProduction = mocks.createMockMemberWithProduction({
       member: mocks.createMockPokemon({ ribbon: 2 })
     })
 
@@ -182,7 +182,7 @@ describe('MemberStats.vue', () => {
   })
 
   it('renders both subskill and ribbon bonuses when both are greater than 0', () => {
-    const productionWithBoth: MemberProductionExt = mocks.createMockMemberProductionExt({
+    const productionWithBoth: MemberWithProduction = mocks.createMockMemberWithProduction({
       member: mocks.createMockPokemon({
         ribbon: 2,
         subskills: [

--- a/frontend/src/components/calculator/results/member-results/member-stats/member-stats.vue
+++ b/frontend/src/components/calculator/results/member-results/member-stats/member-stats.vue
@@ -98,7 +98,7 @@ import { ingredientImage } from '@/services/utils/image-utils'
 import { TimeUtils } from '@/services/utils/time-utils'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { calculateRibbonCarrySize, calculateSubskillCarrySize, limitSubSkillsToLevel, MathUtils } from 'sleepapi-common'
 import { computed, defineComponent, ref, type PropType } from 'vue'
 
@@ -109,11 +109,11 @@ export default defineComponent({
   },
   props: {
     pokemonProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },
-  setup(props: { pokemonProduction: MemberProductionExt }) {
+  setup(props: { pokemonProduction: MemberWithProduction }) {
     const teamStore = useTeamStore()
     const pokemonStore = usePokemonStore()
 

--- a/frontend/src/components/calculator/results/member-results/member-stats/skill-distribution.test.ts
+++ b/frontend/src/components/calculator/results/member-results/member-stats/skill-distribution.test.ts
@@ -9,7 +9,7 @@ describe('SkillDistribution.vue', () => {
   registerChartJS()
   let wrapper: VueWrapper<InstanceType<typeof SkillDistribution>>
 
-  const pokemonProduction = mocks.createMockMemberProductionExt({
+  const pokemonProduction = mocks.createMockMemberWithProduction({
     member: mocks.createMockPokemon({ name: 'Test member' }),
     production: mocks.createMockMemberProduction({
       skillProcs: 5.5,

--- a/frontend/src/components/calculator/results/member-results/member-stats/skill-distribution.vue
+++ b/frontend/src/components/calculator/results/member-results/member-stats/skill-distribution.vue
@@ -32,7 +32,7 @@ import {
   getSkillProcChartOptions
 } from '@/components/calculator/results/member-results/skill-breakdown/skill-proc-distribution-data'
 import BarChart from '@/components/custom-components/charts/bar-chart/bar-chart.vue'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { MathUtils } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 import { useTheme } from 'vuetify'
@@ -44,7 +44,7 @@ export default defineComponent({
   },
   props: {
     pokemonProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   },

--- a/frontend/src/components/calculator/results/member-results/skill-breakdown/skill-breakdown.vue
+++ b/frontend/src/components/calculator/results/member-results/skill-breakdown/skill-breakdown.vue
@@ -12,7 +12,7 @@
 
 <script lang="ts">
 import BarChart from '@/components/custom-components/charts/bar-chart/bar-chart.vue'
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
@@ -22,7 +22,7 @@ export default defineComponent({
   },
   props: {
     pokemonProduction: {
-      type: Object as PropType<MemberProductionExt>,
+      type: Object as PropType<MemberWithProduction>,
       required: true
     }
   }

--- a/frontend/src/components/calculator/results/team-results.test.ts
+++ b/frontend/src/components/calculator/results/team-results.test.ts
@@ -57,8 +57,8 @@ describe('TeamResults', () => {
     const pokemonStore = usePokemonStore()
     pokemonStore.upsertLocalPokemon(mocks.createMockPokemon())
 
-    const baseProduction = mocks.createMockMemberProductionExt().production
-    const memberProduction = mocks.createMockMemberProductionExt({
+    const baseProduction = mocks.createMockMemberWithProduction().production
+    const memberProduction = mocks.createMockMemberWithProduction({
       production: {
         ...baseProduction,
         produceTotal: {

--- a/frontend/src/components/calculator/team-slot.vue
+++ b/frontend/src/components/calculator/team-slot.vue
@@ -116,7 +116,7 @@ import { rarityColor } from '@/services/utils/color-utils'
 import { avatarImage, pokemonImage } from '@/services/utils/image-utils'
 import { useDialogStore } from '@/stores/dialog-store/dialog-store'
 import { useTeamStore } from '@/stores/team/team-store'
-import { MAX_TEAM_SIZE, subskill, type PokemonInstanceExt } from 'sleepapi-common'
+import { MAX_TEAM_SIZE, subskill, type PokemonInstance } from 'sleepapi-common'
 import { defineComponent } from 'vue'
 
 export default defineComponent({
@@ -216,9 +216,9 @@ export default defineComponent({
     }
   },
   methods: {
-    openFilledSlotActions(pokemonInstance: PokemonInstanceExt) {
+    openFilledSlotActions(pokemonInstance: PokemonInstance) {
       this.dialogStore.openFilledSlot(pokemonInstance, this.fullTeam, {
-        onUpdate: (pokemonInstance: PokemonInstanceExt) => {
+        onUpdate: (pokemonInstance: PokemonInstance) => {
           this.updateTeamMember(pokemonInstance)
         },
         onDuplicate: () => {
@@ -233,11 +233,11 @@ export default defineComponent({
       })
     },
     openPokemonSearch() {
-      this.dialogStore.openPokemonSearch((pokemonInstance: PokemonInstanceExt) => {
+      this.dialogStore.openPokemonSearch((pokemonInstance: PokemonInstance) => {
         this.updateTeamMember(pokemonInstance)
       })
     },
-    updateTeamMember(pokemonInstance: PokemonInstanceExt) {
+    updateTeamMember(pokemonInstance: PokemonInstance) {
       this.teamStore.updateTeamMember(pokemonInstance, this.memberIndex)
     },
     duplicateTeamMember() {

--- a/frontend/src/components/compare/compare-slot.test.ts
+++ b/frontend/src/components/compare/compare-slot.test.ts
@@ -3,7 +3,7 @@ import { useDialogStore } from '@/stores/dialog-store/dialog-store'
 import { mocks } from '@/vitest'
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { subskill, type PokemonInstanceExt } from 'sleepapi-common'
+import { subskill, type PokemonInstance } from 'sleepapi-common'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 describe('CompareSlot', () => {
@@ -47,18 +47,18 @@ describe('CompareSlot', () => {
   })
 
   it('emits edit-pokemon event when onUpdate callback is triggered', async () => {
-    const mockPokemonInstanceExt: PokemonInstanceExt = {
+    const mockPokemonInstance: PokemonInstance = {
       ...pokemonInstance,
       name: 'New Name'
     }
     await wrapper.find('.v-card').trigger('click')
 
     if (dialogStore.filledSlotProps.onUpdate) {
-      dialogStore.filledSlotProps.onUpdate(mockPokemonInstanceExt)
+      dialogStore.filledSlotProps.onUpdate(mockPokemonInstance)
     }
 
     expect(wrapper.emitted('edit-pokemon')).toBeTruthy()
-    expect(wrapper.emitted('edit-pokemon')![0][0]).toEqual(mockPokemonInstanceExt)
+    expect(wrapper.emitted('edit-pokemon')![0][0]).toEqual(mockPokemonInstance)
   })
 
   it('emits duplicate-pokemon event when onDuplicate callback is triggered', async () => {

--- a/frontend/src/components/compare/compare-slot.vue
+++ b/frontend/src/components/compare/compare-slot.vue
@@ -31,14 +31,14 @@ import { pokemonImage } from '@/services/utils/image-utils'
 import { useComparisonStore } from '@/stores/comparison-store/comparison-store'
 import { useDialogStore } from '@/stores/dialog-store/dialog-store'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
-import { RP, type PokemonInstanceExt } from 'sleepapi-common'
+import { RP, type PokemonInstance } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   name: 'CompareSlot',
   props: {
     pokemonInstance: {
-      type: Object as PropType<PokemonInstanceExt>,
+      type: Object as PropType<PokemonInstance>,
       required: true
     }
   },
@@ -72,7 +72,7 @@ export default defineComponent({
   methods: {
     openDialog() {
       this.dialogStore.openFilledSlot(this.pokemonInstance, this.comparisonStore.fullTeam, {
-        onUpdate: (pokemon: PokemonInstanceExt) => {
+        onUpdate: (pokemon: PokemonInstance) => {
           this.$emit('edit-pokemon', pokemon)
         },
         onDuplicate: () => {

--- a/frontend/src/components/pokemon-input/PokemonSearch.vue
+++ b/frontend/src/components/pokemon-input/PokemonSearch.vue
@@ -156,20 +156,20 @@ import {
   COMPLETE_POKEDEX,
   hasSpecialty,
   type Pokemon,
-  type PokemonInstanceExt,
+  type PokemonInstance,
   type PokemonSpecialty
 } from 'sleepapi-common'
 import { computed, ref, watch, type ComputedRef, type Ref } from 'vue'
 
 const emit = defineEmits<{
   cancel: []
-  save: [pokemon: PokemonInstanceExt]
+  save: [pokemon: PokemonInstance]
 }>()
 
 export interface PokemonWithPath {
   path: string
   pokemon: Pokemon
-  instance: PokemonInstanceExt
+  instance: PokemonInstance
 }
 
 const pokemonSearchStore = usePokemonSearchStore()
@@ -332,7 +332,7 @@ const selectFirstOption = () => {
   }
 }
 
-const selectPokemon = (instance: PokemonInstanceExt) => {
+const selectPokemon = (instance: PokemonInstance) => {
   if (dialogStore.pokemonSearchCallback) {
     // If selecting from Pokebox, use the instance directly
     if (pokemonSearchStore.showPokebox) {
@@ -350,7 +350,7 @@ const selectPokemon = (instance: PokemonInstanceExt) => {
         emit('save', finalInstance)
       } else {
         // No current instance (new pokemon scenario) - open pokemon input for customization
-        dialogStore.openPokemonInput((updatedInstance: PokemonInstanceExt) => {
+        dialogStore.openPokemonInput((updatedInstance: PokemonInstance) => {
           dialogStore.handlePokemonSelected(updatedInstance)
           emit('save', updatedInstance)
         }, instance)
@@ -358,7 +358,7 @@ const selectPokemon = (instance: PokemonInstanceExt) => {
     }
   } else {
     // No callback - open pokemon input dialog for standalone usage
-    dialogStore.openPokemonInput((updatedInstance: PokemonInstanceExt) => {
+    dialogStore.openPokemonInput((updatedInstance: PokemonInstance) => {
       emit('save', updatedInstance)
     }, instance)
   }

--- a/frontend/src/components/pokemon-input/PokemonSearchDialog.vue
+++ b/frontend/src/components/pokemon-input/PokemonSearchDialog.vue
@@ -6,12 +6,12 @@
 
 <script setup lang="ts">
 import { useDialogStore } from '@/stores/dialog-store/dialog-store'
-import type { PokemonInstanceExt } from 'sleepapi-common'
+import type { PokemonInstance } from 'sleepapi-common'
 import PokemonSearch from './PokemonSearch.vue'
 
 const dialogStore = useDialogStore()
 
-const handlePokemonSave = (instance: PokemonInstanceExt) => {
+const handlePokemonSave = (instance: PokemonInstance) => {
   dialogStore.handlePokemonSelected(instance)
 }
 </script>

--- a/frontend/src/components/pokemon-input/carry-size-display.test.ts
+++ b/frontend/src/components/pokemon-input/carry-size-display.test.ts
@@ -1,7 +1,7 @@
 import CarrySizeDisplay from '@/components/pokemon-input/carry-size-display.vue'
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { commonMocks, subskill, type Pokemon, type PokemonInstanceExt, type SubskillInstanceExt } from 'sleepapi-common'
+import { commonMocks, subskill, type Pokemon, type PokemonInstance, type SubskillInstance } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 describe('CarrySizeDisplay', () => {
@@ -11,8 +11,8 @@ describe('CarrySizeDisplay', () => {
     pokemon: commonMocks.mockPokemon(), //base carry size 0
     carrySize: 0,
     level: 50,
-    subskills: [] as SubskillInstanceExt[]
-  } as PokemonInstanceExt
+    subskills: [] as SubskillInstance[]
+  } as PokemonInstance
 
   const venusaur = {
     name: 'Venusaur',

--- a/frontend/src/components/pokemon-input/carry-size-display.vue
+++ b/frontend/src/components/pokemon-input/carry-size-display.vue
@@ -8,7 +8,7 @@ import {
   calculateSubskillCarrySize,
   CarrySizeUtils,
   limitSubSkillsToLevel,
-  type PokemonInstanceExt
+  type PokemonInstance
 } from 'sleepapi-common'
 import type { PropType } from 'vue'
 
@@ -16,7 +16,7 @@ export default {
   name: 'CarrySizeDisplay',
   props: {
     pokemonInstance: {
-      type: Object as PropType<PokemonInstanceExt>,
+      type: Object as PropType<PokemonInstance>,
       required: true
     }
   },

--- a/frontend/src/components/pokemon-input/gender-button.vue
+++ b/frontend/src/components/pokemon-input/gender-button.vue
@@ -16,14 +16,14 @@
 </template>
 
 <script lang="ts">
-import { allowsGenderToggle, fixedGenderForSpecies, type PokemonInstanceExt } from 'sleepapi-common'
+import { allowsGenderToggle, fixedGenderForSpecies, type PokemonInstance } from 'sleepapi-common'
 import type { PropType } from 'vue'
 
 export default {
   name: 'GenderButton',
   props: {
     pokemonInstance: {
-      type: Object as PropType<PokemonInstanceExt>,
+      type: Object as PropType<PokemonInstance>,
       required: true
     }
   },

--- a/frontend/src/components/pokemon-input/ingredient-button.test.ts
+++ b/frontend/src/components/pokemon-input/ingredient-button.test.ts
@@ -7,20 +7,20 @@ import {
   ingredient,
   PIKACHU,
   PINSIR,
-  type IngredientInstanceExt,
+  type IngredientInstance,
   type IngredientSet,
-  type PokemonInstanceExt
+  type PokemonInstance
 } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it, vitest } from 'vitest'
 
 describe('IngredientButton', () => {
   let wrapper: VueWrapper<InstanceType<typeof IngredientButton>>
 
-  const mockPokemon: PokemonInstanceExt = {
+  const mockPokemon: PokemonInstance = {
     level: 60,
     pokemon: PIKACHU,
-    ingredients: [] as IngredientInstanceExt[]
-  } as PokemonInstanceExt
+    ingredients: [] as IngredientInstance[]
+  } as PokemonInstance
 
   beforeEach(() => {
     wrapper = mount(IngredientButton, {

--- a/frontend/src/components/pokemon-input/ingredient-button.vue
+++ b/frontend/src/components/pokemon-input/ingredient-button.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script lang="ts">
-import { commonMocks, type IngredientSet, type Pokemon, type PokemonInstanceExt } from 'sleepapi-common'
+import { commonMocks, type IngredientSet, type Pokemon, type PokemonInstance } from 'sleepapi-common'
 import type { PropType } from 'vue'
 
 export default {
@@ -48,7 +48,7 @@ export default {
       required: true
     },
     pokemonInstance: {
-      type: Object as PropType<PokemonInstanceExt>,
+      type: Object as PropType<PokemonInstance>,
       required: true
     }
   },

--- a/frontend/src/components/pokemon-input/mainskill-button.test.ts
+++ b/frontend/src/components/pokemon-input/mainskill-button.test.ts
@@ -3,7 +3,7 @@ import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { mocks } from '@/vitest'
 import type { VueWrapper } from '@vue/test-utils'
 import { mount } from '@vue/test-utils'
-import { GENGAR, Mainskill, PLUSLE, type AmountParams, type PokemonInstanceExt } from 'sleepapi-common'
+import { GENGAR, Mainskill, PLUSLE, type AmountParams, type PokemonInstance } from 'sleepapi-common'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 describe('MainskillButton', () => {
@@ -64,7 +64,7 @@ describe('MainskillButton', () => {
       activations = {}
     })(false, true)
 
-    const changedPokemon: PokemonInstanceExt = {
+    const changedPokemon: PokemonInstance = {
       ...mockPokemon,
       pokemon: { ...mockPokemon.pokemon, skill: skillWithLowMaxLevel }
     }

--- a/frontend/src/components/pokemon-input/mainskill-button.vue
+++ b/frontend/src/components/pokemon-input/mainskill-button.vue
@@ -44,14 +44,14 @@
 
 <script lang="ts">
 import { mainskillImage } from '@/services/utils/image-utils'
-import { type PokemonInstanceExt } from 'sleepapi-common'
+import { type PokemonInstance } from 'sleepapi-common'
 import type { PropType } from 'vue'
 
 export default {
   name: 'MainskillButton',
   props: {
     pokemonInstance: {
-      type: Object as PropType<PokemonInstanceExt>,
+      type: Object as PropType<PokemonInstance>,
       required: true
     }
   },
@@ -59,7 +59,7 @@ export default {
   setup() {
     return { mainskillImage }
   },
-  data(this: { pokemonInstance: PokemonInstanceExt }) {
+  data(this: { pokemonInstance: PokemonInstance }) {
     return {
       mainskillLevel: this.pokemonInstance.skillLevel,
       menu: false

--- a/frontend/src/components/pokemon-input/menus/subskill-button.test.ts
+++ b/frontend/src/components/pokemon-input/menus/subskill-button.test.ts
@@ -1,11 +1,11 @@
 import SubskillButton from '@/components/pokemon-input/menus/subskill-button.vue'
 import { mount } from '@vue/test-utils'
-import { subskill, type SubskillInstanceExt } from 'sleepapi-common'
+import { subskill, type SubskillInstance } from 'sleepapi-common'
 import { describe, expect, it } from 'vitest'
 
 const mockSubskill = subskill.BERRY_FINDING_S
 
-const selectedSubskills: SubskillInstanceExt[] = [
+const selectedSubskills: SubskillInstance[] = [
   {
     subskill: mockSubskill,
     level: 10

--- a/frontend/src/components/pokemon-input/menus/subskill-button.vue
+++ b/frontend/src/components/pokemon-input/menus/subskill-button.vue
@@ -18,7 +18,7 @@
 
 <script lang="ts">
 import { rarityColor } from '@/services/utils/color-utils'
-import { type Subskill, type SubskillInstanceExt } from 'sleepapi-common'
+import { type Subskill, type SubskillInstance } from 'sleepapi-common'
 import type { PropType } from 'vue'
 
 export default {
@@ -34,7 +34,7 @@ export default {
       default: undefined
     },
     selectedSubskills: {
-      type: Array<SubskillInstanceExt>,
+      type: Array<SubskillInstance>,
       required: true,
       default: () => []
     }
@@ -48,7 +48,7 @@ export default {
     },
     level() {
       return this.selectedSubskills.find(
-        (ssExt) => ssExt.subskill.name.toLowerCase() === this.subskill.name.toLowerCase()
+        (subskillInstance) => subskillInstance.subskill.name.toLowerCase() === this.subskill.name.toLowerCase()
       )?.level
     }
   }

--- a/frontend/src/components/pokemon-input/menus/subskill-buttons.vue
+++ b/frontend/src/components/pokemon-input/menus/subskill-buttons.vue
@@ -41,7 +41,7 @@
 <script lang="ts">
 import SubskillMenu from '@/components/pokemon-input/menus/subskill-menu.vue'
 import { rarityColor } from '@/services/utils/color-utils'
-import { subskill, type Subskill, type SubskillInstanceExt } from 'sleepapi-common'
+import { subskill, type Subskill, type SubskillInstance } from 'sleepapi-common'
 
 export default {
   name: 'SubskillButtons',
@@ -54,7 +54,7 @@ export default {
       required: true
     },
     selectedSubskills: {
-      type: Array<SubskillInstanceExt>,
+      type: Array<SubskillInstance>,
       required: true,
       default: () => []
     }
@@ -92,9 +92,9 @@ export default {
   },
   methods: {
     subskillForLevel(subskillLevel: number): Subskill | undefined {
-      return this.selectedSubskills.find((ssExt) => ssExt.level === subskillLevel)?.subskill
+      return this.selectedSubskills.find((subskillInstance) => subskillInstance.level === subskillLevel)?.subskill
     },
-    updateSubskills(updatedSubskills: SubskillInstanceExt[]) {
+    updateSubskills(updatedSubskills: SubskillInstance[]) {
       this.toggleSubskillMenu()
       this.$emit('update-subskills', updatedSubskills)
     },

--- a/frontend/src/components/pokemon-input/menus/subskill-menu.test.ts
+++ b/frontend/src/components/pokemon-input/menus/subskill-menu.test.ts
@@ -1,10 +1,10 @@
 import SubskillMenu from '@/components/pokemon-input/menus/subskill-menu.vue'
 import { mount } from '@vue/test-utils'
-import { subskill, type SubskillInstanceExt } from 'sleepapi-common'
+import { subskill, type SubskillInstance } from 'sleepapi-common'
 import { describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
 
-const mockCurrentSubskills: SubskillInstanceExt[] = [
+const mockCurrentSubskills: SubskillInstance[] = [
   {
     subskill: subskill.BERRY_FINDING_S,
     level: 10

--- a/frontend/src/components/pokemon-input/menus/subskill-menu.vue
+++ b/frontend/src/components/pokemon-input/menus/subskill-menu.vue
@@ -216,14 +216,14 @@
 <script lang="ts">
 import CustomLabel from '@/components/custom-components/custom-label.vue'
 import SubskillButton from '@/components/pokemon-input/menus/subskill-button.vue'
-import { type Subskill, type SubskillInstanceExt } from 'sleepapi-common'
+import { type Subskill, type SubskillInstance } from 'sleepapi-common'
 
 export default {
   name: 'SubskillMenu',
   components: { SubskillButton, CustomLabel },
   props: {
     currentSubskills: {
-      type: Array<SubskillInstanceExt>,
+      type: Array<SubskillInstance>,
       required: true,
       default: []
     },
@@ -234,7 +234,7 @@ export default {
   },
   emits: ['cancel', 'update-subskills'],
   data: () => ({
-    selectedSubskills: [] as SubskillInstanceExt[],
+    selectedSubskills: [] as SubskillInstance[],
     availableLevels: [10, 25, 50, 70, 80]
   }),
   computed: {
@@ -254,7 +254,7 @@ export default {
   },
   methods: {
     subskillForLevel(subskillLevel: number): Subskill | undefined {
-      return this.currentSubskills.find((ssExt) => ssExt.level === subskillLevel)?.subskill
+      return this.currentSubskills.find((subskillInstance) => subskillInstance.level === subskillLevel)?.subskill
     },
     toggleSubskill(ss: Subskill) {
       const index = this.selectedSubskills.findIndex((s) => s.subskill.name.toLowerCase() === ss.name.toLowerCase())

--- a/frontend/src/components/pokemon-input/pokemon-button.vue
+++ b/frontend/src/components/pokemon-input/pokemon-button.vue
@@ -19,20 +19,20 @@
 <script setup lang="ts">
 import { pokemonImage } from '@/services/utils/image-utils'
 import { useDialogStore } from '@/stores/dialog-store/dialog-store'
-import type { PokemonInstanceExt } from 'sleepapi-common'
+import type { PokemonInstance } from 'sleepapi-common'
 
 const props = defineProps<{
-  pokemonInstance: PokemonInstanceExt
+  pokemonInstance: PokemonInstance
 }>()
 
 const emit = defineEmits<{
-  'update-pokemon': [pokemon: PokemonInstanceExt]
+  'update-pokemon': [pokemon: PokemonInstance]
 }>()
 
 const dialogStore = useDialogStore()
 
 const openMenu = () => {
-  dialogStore.openPokemonSearch((pokemon: PokemonInstanceExt) => {
+  dialogStore.openPokemonSearch((pokemon: PokemonInstance) => {
     emit('update-pokemon', pokemon)
   }, props.pokemonInstance)
 }

--- a/frontend/src/components/pokemon-input/pokemon-input.test.ts
+++ b/frontend/src/components/pokemon-input/pokemon-input.test.ts
@@ -12,7 +12,7 @@ import {
   SNEASEL,
   subskill,
   WEAVILE,
-  type PokemonInstanceExt
+  type PokemonInstance
 } from 'sleepapi-common'
 import { vimic } from 'vimic'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -21,7 +21,7 @@ describe('PokemonInput', () => {
   let wrapper: VueWrapper<InstanceType<typeof PokemonInput>>
   console.error = vi.fn()
 
-  const preExistingMon: PokemonInstanceExt = mocks.createMockPokemon()
+  const preExistingMon: PokemonInstance = mocks.createMockPokemon()
 
   beforeEach(() => {
     wrapper = mount(PokemonInput, {

--- a/frontend/src/components/pokemon-input/pokemon-input.test.ts
+++ b/frontend/src/components/pokemon-input/pokemon-input.test.ts
@@ -13,7 +13,7 @@ import {
   SNEASEL,
   subskill,
   WEAVILE,
-  type PokemonInstanceExt
+  type PokemonInstance
 } from 'sleepapi-common'
 import { vimic } from 'vimic'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -22,7 +22,7 @@ describe('PokemonInput', () => {
   let wrapper: VueWrapper<InstanceType<typeof PokemonInput>>
   console.error = vi.fn()
 
-  const preExistingMon: PokemonInstanceExt = mocks.createMockPokemon()
+  const preExistingMon: PokemonInstance = mocks.createMockPokemon()
 
   beforeEach(() => {
     wrapper = mount(PokemonInput, {

--- a/frontend/src/components/pokemon-input/pokemon-input.vue
+++ b/frontend/src/components/pokemon-input/pokemon-input.vue
@@ -169,8 +169,8 @@ import {
   RP,
   type IngredientSet,
   type PokemonGender,
-  type PokemonInstanceExt,
-  type SubskillInstanceExt
+  type PokemonInstance,
+  type SubskillInstance
 } from 'sleepapi-common'
 import { defineComponent, nextTick, type PropType } from 'vue'
 
@@ -190,7 +190,7 @@ export default defineComponent({
   },
   props: {
     preSelectedPokemonInstance: {
-      type: Object as PropType<PokemonInstanceExt>,
+      type: Object as PropType<PokemonInstance>,
       required: true
     }
   },
@@ -204,7 +204,7 @@ export default defineComponent({
 
     return { teamStore, userStore, viewportWidth, pokemonNameBreakpoint }
   },
-  data(this: { preSelectedPokemonInstance: PokemonInstanceExt }) {
+  data(this: { preSelectedPokemonInstance: PokemonInstance }) {
     const { pokemon: _, ...pokemonInstanceWithoutPokemon } = this.preSelectedPokemonInstance
 
     return {
@@ -213,13 +213,13 @@ export default defineComponent({
         ...JSON.parse(JSON.stringify(pokemonInstanceWithoutPokemon)),
         // Get fresh pokemon instance with classes intact
         pokemon: getPokemon(this.preSelectedPokemonInstance.pokemon.name)
-      } as PokemonInstanceExt
+      } as PokemonInstance
     }
   },
   watch: {
     pokemonInstance: {
       deep: true,
-      handler(newPokemon: PokemonInstanceExt) {
+      handler(newPokemon: PokemonInstance) {
         nextTick(() => {
           const rp = new RP({ ...newPokemon, ingredients: newPokemon.ingredients.filter(Boolean) })
           this.pokemonInstance.rp = rp.calc()
@@ -255,11 +255,11 @@ export default defineComponent({
     updateGender(gender: PokemonGender) {
       this.pokemonInstance.gender = gender
     },
-    updateSubskills(updatedSubskills: SubskillInstanceExt[]) {
+    updateSubskills(updatedSubskills: SubskillInstance[]) {
       this.pokemonInstance.subskills = updatedSubskills
       this.pokemonInstance.subskills.sort((a, b) => a.level - b.level)
     },
-    updatePokemon(instance: PokemonInstanceExt) {
+    updatePokemon(instance: PokemonInstance) {
       this.pokemonInstance = instance
     },
     updateName(newName: string) {

--- a/frontend/src/components/pokemon-input/pokemon-name.vue
+++ b/frontend/src/components/pokemon-input/pokemon-name.vue
@@ -42,14 +42,14 @@
 <script lang="ts">
 import { useHighlightText } from '@/composables/highlight-text/use-highlight-text'
 import { randomName } from '@/services/utils/name-utils'
-import type { PokemonInstanceExt } from 'sleepapi-common'
+import type { PokemonInstance } from 'sleepapi-common'
 import type { PropType } from 'vue'
 
 export default {
   name: 'PokemonName',
   props: {
     pokemonInstance: {
-      type: Object as PropType<PokemonInstanceExt>,
+      type: Object as PropType<PokemonInstance>,
       required: true
     }
   },

--- a/frontend/src/components/pokemon-input/ribbon-button.vue
+++ b/frontend/src/components/pokemon-input/ribbon-button.vue
@@ -26,7 +26,7 @@
 </template>
 
 <script lang="ts">
-import type { PokemonInstanceExt } from 'sleepapi-common'
+import type { PokemonInstance } from 'sleepapi-common'
 import type { PropType } from 'vue'
 import CarrySizeDisplay from './carry-size-display.vue'
 
@@ -37,7 +37,7 @@ export default {
   },
   props: {
     pokemonInstance: {
-      type: Object as PropType<PokemonInstanceExt>,
+      type: Object as PropType<PokemonInstance>,
       required: true
     }
   },

--- a/frontend/src/components/speech-bubble/speech-bubble.vue
+++ b/frontend/src/components/speech-bubble/speech-bubble.vue
@@ -26,14 +26,14 @@
 </template>
 
 <script lang="ts">
-import { type PokemonInstanceExt } from 'sleepapi-common'
+import { type PokemonInstance } from 'sleepapi-common'
 import { defineComponent, type PropType } from 'vue'
 
 export default defineComponent({
   name: 'SpeechBubble',
   props: {
     pokemonInstance: {
-      type: Object as PropType<PokemonInstanceExt>,
+      type: Object as PropType<PokemonInstance>,
       required: true
     }
   }

--- a/frontend/src/components/tierlist/tabs/RecipesTab.vue
+++ b/frontend/src/components/tierlist/tabs/RecipesTab.vue
@@ -254,7 +254,7 @@ import {
   MAX_RIBBON_LEVEL,
   MAX_TEAM_SIZE,
   uuid,
-  type PokemonInstanceExt,
+  type PokemonInstance,
   type PokemonWithTiering,
   type RecipeContribution,
   type TeamMemberProduction,
@@ -507,7 +507,7 @@ const simulateRecipe = async (contribution: RecipeContribution) => {
           saved: false,
           externalId: uuid.v4(),
           name: randomName(pokemon, 12, getRandomGender(pokemon))
-        } as PokemonInstanceExt
+        } as PokemonInstance
       })
     }
 

--- a/frontend/src/pages/compare/comparison-page.test.ts
+++ b/frontend/src/pages/compare/comparison-page.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TeamService } from '@/services/team/team-service'
 import { useComparisonStore } from '@/stores/comparison-store/comparison-store'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
-import type { TeamProductionExt } from '@/types/member/instanced'
+import type { TeamProduction } from '@/types/member/instanced'
 import { mocks } from '@/vitest'
 import { nextTick } from 'vue'
 
@@ -17,7 +17,7 @@ describe('ComparisonPage', () => {
   let wrapper: VueWrapper<InstanceType<typeof ComparisonPage>>
   let pokemonStore: ReturnType<typeof usePokemonStore>
 
-  const mockResponse: TeamProductionExt = mocks.createMockTeamProduction()
+  const mockResponse: TeamProduction = mocks.createMockTeamProduction()
   const mockPokemon = mocks.createMockPokemon()
   const mockMemberProduction: MemberProduction = mocks.createMockMemberProduction()
 

--- a/frontend/src/pages/compare/comparison-page.vue
+++ b/frontend/src/pages/compare/comparison-page.vue
@@ -75,7 +75,7 @@ import { useComparisonStore } from '@/stores/comparison-store/comparison-store'
 import { useDialogStore } from '@/stores/dialog-store/dialog-store'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { UnexpectedError } from '@/types/errors/unexpected-error'
-import { DEFAULT_ISLAND, uuid, type PokemonInstanceExt, type TeamSettings } from 'sleepapi-common'
+import { DEFAULT_ISLAND, uuid, type PokemonInstance, type TeamSettingsDto } from 'sleepapi-common'
 import { defineComponent } from 'vue'
 
 export default defineComponent({
@@ -104,7 +104,7 @@ export default defineComponent({
   }),
   computed: {
     members() {
-      const members: PokemonInstanceExt[] = []
+      const members: PokemonInstance[] = []
       for (const member of this.comparisonStore.members) {
         const pokemon = this.pokemonStore.getPokemon(member.externalId)
         pokemon && members.push(pokemon)
@@ -118,7 +118,7 @@ export default defineComponent({
         this.addToCompareMembers(pokemonInstance)
       })
     },
-    async addToCompareMembers(pokemonInstance: PokemonInstanceExt) {
+    async addToCompareMembers(pokemonInstance: PokemonInstance) {
       this.loading = true
       const memberProduction = await this.fetchCompareMemberProduction(pokemonInstance)
       this.comparisonStore.members.push(memberProduction)
@@ -132,10 +132,10 @@ export default defineComponent({
 
       this.loading = false
     },
-    async removeCompareMember(pokemonInstance: PokemonInstanceExt, index: number) {
+    async removeCompareMember(pokemonInstance: PokemonInstance, index: number) {
       this.comparisonStore.removeMember(pokemonInstance.externalId, index)
     },
-    async editCompareMember(pokemonInstance: PokemonInstanceExt) {
+    async editCompareMember(pokemonInstance: PokemonInstance) {
       this.loading = true
       const memberProduction = await this.fetchCompareMemberProduction(pokemonInstance)
 
@@ -153,8 +153,8 @@ export default defineComponent({
       this.comparisonStore.members[indexToUpdate] = memberProduction
       this.loading = false
     },
-    async fetchCompareMemberProduction(pokemonInstance: PokemonInstanceExt) {
-      const members: PokemonInstanceExt[] = [pokemonInstance]
+    async fetchCompareMemberProduction(pokemonInstance: PokemonInstance) {
+      const members: PokemonInstance[] = [pokemonInstance]
       const maybeTeam = this.comparisonStore.currentTeam
       for (const member of maybeTeam?.members ?? []) {
         if (member) {
@@ -162,7 +162,7 @@ export default defineComponent({
           pokemon && members.push(pokemon)
         }
       }
-      const settings: TeamSettings = {
+      const settings: TeamSettingsDto = {
         camp: maybeTeam?.camp ?? false,
         bedtime: maybeTeam?.bedtime ?? '21:30',
         wakeup: maybeTeam?.wakeup ?? '06:00',
@@ -180,14 +180,14 @@ export default defineComponent({
 
       return production
     },
-    duplicateCompareMember(pokemonInstance: PokemonInstanceExt) {
+    duplicateCompareMember(pokemonInstance: PokemonInstance) {
       const copiedProduction = this.comparisonStore.members.find(
         (pkmn) => pkmn.externalId === pokemonInstance.externalId
       )
       if (!copiedProduction) {
         console.error("Can't find pokemon to duplicate in the list, contact developer")
       } else {
-        const duplicatedMember: PokemonInstanceExt = {
+        const duplicatedMember: PokemonInstance = {
           ...pokemonInstance,
           version: 0,
           saved: false,
@@ -201,7 +201,7 @@ export default defineComponent({
         this.pokemonStore.upsertLocalPokemon(duplicatedMember)
       }
     },
-    toggleSaveState(pokemonInstance: PokemonInstanceExt) {
+    toggleSaveState(pokemonInstance: PokemonInstance) {
       const previouslyExisted = this.pokemonStore.getPokemon(pokemonInstance.externalId)
       if (previouslyExisted?.saved || pokemonInstance.saved) {
         this.pokemonStore.upsertServerPokemon(pokemonInstance)

--- a/frontend/src/services/team/team-service.test.ts
+++ b/frontend/src/services/team/team-service.test.ts
@@ -17,8 +17,8 @@ import {
   type CalculateIvResponse,
   type GetTeamResponse,
   type MemberProductionBase,
-  type PokemonInstanceExt,
-  type TeamSettings,
+  type PokemonInstance,
+  type TeamSettingsDto,
   type UpsertTeamMetaRequest
 } from 'sleepapi-common'
 
@@ -244,7 +244,7 @@ describe('createOrUpdateMember', () => {
   it('should call server to create or update a member and return the updated member', async () => {
     const teamIndex = 0
     const memberIndex = 0
-    const member: PokemonInstanceExt = mocks.createMockPokemon()
+    const member: PokemonInstance = mocks.createMockPokemon()
     serverAxios.put = vi.fn().mockResolvedValueOnce({
       data: {
         index: 1,
@@ -357,8 +357,8 @@ describe('deleteTeam', () => {
 
 describe('calculateProduction', () => {
   it('should call server to calculate team production', async () => {
-    const members: PokemonInstanceExt[] = [mocks.createMockPokemon()]
-    const settings: TeamSettings = {
+    const members: PokemonInstance[] = [mocks.createMockPokemon()]
+    const settings: TeamSettingsDto = {
       camp: false,
       bedtime: '21:00',
       wakeup: '07:00',

--- a/frontend/src/services/team/team-service.ts
+++ b/frontend/src/services/team/team-service.ts
@@ -4,7 +4,7 @@ import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useTeamStore } from '@/stores/team/team-store'
 import { useUserStore } from '@/stores/user-store'
 import { UnexpectedError } from '@/types/errors/unexpected-error'
-import { type TeamCombinedProduction, type TeamInstance, type TeamProductionExt } from '@/types/member/instanced'
+import { type TeamCombinedProduction, type TeamInstance, type TeamProduction } from '@/types/member/instanced'
 import {
   berry,
   DEFAULT_ISLAND,
@@ -20,10 +20,10 @@ import {
   type GetTeamsResponse,
   type IngredientSet,
   type IslandInstance,
-  type PokemonInstanceExt,
+  type PokemonInstance,
   type PokemonInstanceIdentity,
   type TeamAreaDTO,
-  type TeamSettings,
+  type TeamSettingsDto,
   type UpsertTeamMemberResponse,
   type UpsertTeamMetaRequest,
   type UpsertTeamMetaResponse
@@ -36,7 +36,7 @@ class TeamServiceImpl {
     return response.data
   }
 
-  public async createOrUpdateMember(params: { teamIndex: number; memberIndex: number; member: PokemonInstanceExt }) {
+  public async createOrUpdateMember(params: { teamIndex: number; memberIndex: number; member: PokemonInstance }) {
     const { teamIndex, memberIndex, member } = params
 
     const request = PokemonInstanceUtils.toUpsertTeamMemberRequest(member)
@@ -80,7 +80,7 @@ class TeamServiceImpl {
           if (!serverMember) {
             members.push(undefined)
           } else {
-            const cachedMember = PokemonInstanceUtils.toPokemonInstanceExt(serverMember)
+            const cachedMember = PokemonInstanceUtils.toPokemonInstance(serverMember)
             pokemonStore.upsertLocalPokemon(cachedMember)
             members.push(cachedMember.externalId)
           }
@@ -138,9 +138,9 @@ class TeamServiceImpl {
   }
 
   public async calculateProduction(params: {
-    members: PokemonInstanceExt[]
-    settings: TeamSettings
-  }): Promise<TeamProductionExt | undefined> {
+    members: PokemonInstance[]
+    settings: TeamSettingsDto
+  }): Promise<TeamProduction | undefined> {
     const { members, settings } = params
     if (members.length === 0) {
       return undefined
@@ -180,7 +180,7 @@ class TeamServiceImpl {
     }
     const currentTeam = teamStore.getCurrentTeam
 
-    const members: PokemonInstanceExt[] = []
+    const members: PokemonInstance[] = []
     for (const memberId of currentTeam.members) {
       if (memberId && memberId !== teamStore.getCurrentMember) {
         const member = pokemonStore.getPokemon(memberId)
@@ -188,7 +188,7 @@ class TeamServiceImpl {
       }
     }
 
-    const settings: TeamSettings = {
+    const settings: TeamSettingsDto = {
       camp: currentTeam.camp,
       bedtime: currentTeam.bedtime,
       wakeup: currentTeam.wakeup,

--- a/frontend/src/services/user/user-service.ts
+++ b/frontend/src/services/user/user-service.ts
@@ -4,7 +4,7 @@ import { useUserStore } from '@/stores/user-store'
 import type {
   GetRecipeLevelsResponse,
   IslandShortName,
-  PokemonInstanceExt,
+  PokemonInstance,
   PokemonInstanceWithMeta,
   UpdateUserRequest,
   UpsertAreaBonusRequest,
@@ -25,10 +25,10 @@ class UserServiceImpl {
 
     const savedPokemon = response.data
 
-    return savedPokemon.map(PokemonInstanceUtils.toPokemonInstanceExt)
+    return savedPokemon.map(PokemonInstanceUtils.toPokemonInstance)
   }
 
-  public async upsertPokemon(pokemonInstance: PokemonInstanceExt) {
+  public async upsertPokemon(pokemonInstance: PokemonInstance) {
     const request = PokemonInstanceUtils.toUpsertTeamMemberRequest(pokemonInstance)
     return serverAxios.put('user/pokemon', request)
   }

--- a/frontend/src/services/utils/pokemon-instance-utils.test.ts
+++ b/frontend/src/services/utils/pokemon-instance-utils.test.ts
@@ -10,30 +10,30 @@ import {
   Ribbon,
   RP,
   subskill,
-  type PokemonInstanceExt,
+  type PokemonInstance,
   type PokemonInstanceWithMeta
 } from 'sleepapi-common'
 import { describe, expect, it } from 'vitest'
 
-const mockPokemonInstanceExt: PokemonInstanceExt = mocks.createMockPokemon({
+const mockPokemonInstance: PokemonInstance = mocks.createMockPokemon({
   subskills: [
     { level: 10, subskill: subskill.HELPING_BONUS },
     { level: 25, subskill: subskill.BERRY_FINDING_S }
   ]
 })
 const mockPokemonInstanceWithMeta: PokemonInstanceWithMeta = {
-  version: mockPokemonInstanceExt.version,
-  saved: mockPokemonInstanceExt.saved,
-  shiny: mockPokemonInstanceExt.shiny,
-  gender: mockPokemonInstanceExt.gender,
-  externalId: mockPokemonInstanceExt.externalId,
-  pokemon: mockPokemonInstanceExt.pokemon.name,
-  name: mockPokemonInstanceExt.name,
-  level: mockPokemonInstanceExt.level,
-  ribbon: mockPokemonInstanceExt.ribbon,
-  carrySize: CarrySizeUtils.baseCarrySize(mockPokemonInstanceExt.pokemon),
-  skillLevel: mockPokemonInstanceExt.skillLevel,
-  nature: mockPokemonInstanceExt.nature.name,
+  version: mockPokemonInstance.version,
+  saved: mockPokemonInstance.saved,
+  shiny: mockPokemonInstance.shiny,
+  gender: mockPokemonInstance.gender,
+  externalId: mockPokemonInstance.externalId,
+  pokemon: mockPokemonInstance.pokemon.name,
+  name: mockPokemonInstance.name,
+  level: mockPokemonInstance.level,
+  ribbon: mockPokemonInstance.ribbon,
+  carrySize: CarrySizeUtils.baseCarrySize(mockPokemonInstance.pokemon),
+  skillLevel: mockPokemonInstance.skillLevel,
+  nature: mockPokemonInstance.nature.name,
   subskills: [
     { level: 10, subskill: 'Helping Bonus' },
     { level: 25, subskill: 'Berry Finding S' }
@@ -46,10 +46,10 @@ const mockPokemonInstanceWithMeta: PokemonInstanceWithMeta = {
   sneakySnacking: false
 }
 
-describe('toPokemonInstanceExt', () => {
-  it('should convert a valid PokemonInstanceWithMeta to PokemonInstanceExt', () => {
-    const result = PokemonInstanceUtils.toPokemonInstanceExt(mockPokemonInstanceWithMeta)
-    expect(result).toEqual({ ...mockPokemonInstanceExt, rp: 834 })
+describe('toPokemonInstance', () => {
+  it('should convert a valid PokemonInstanceWithMeta to PokemonInstance', () => {
+    const result = PokemonInstanceUtils.toPokemonInstance(mockPokemonInstanceWithMeta)
+    expect(result).toEqual({ ...mockPokemonInstance, rp: 834 })
   })
 
   it('should throw an error if ingredient data is corrupt (not exactly 3)', () => {
@@ -58,7 +58,7 @@ describe('toPokemonInstanceExt', () => {
       ingredients: [{ level: 0, name: 'incorrect', amount: 2 }]
     }
 
-    expect(() => PokemonInstanceUtils.toPokemonInstanceExt(corruptInstance)).toThrow('Received corrupt ingredient data')
+    expect(() => PokemonInstanceUtils.toPokemonInstance(corruptInstance)).toThrow('Received corrupt ingredient data')
   })
 
   it('should throw an error if subskill data is corrupt (more than 5)', () => {
@@ -74,19 +74,19 @@ describe('toPokemonInstanceExt', () => {
       ]
     }
 
-    expect(() => PokemonInstanceUtils.toPokemonInstanceExt(corruptInstance)).toThrow('Received corrupt subskill data')
+    expect(() => PokemonInstanceUtils.toPokemonInstance(corruptInstance)).toThrow('Received corrupt subskill data')
   })
 })
 
 describe('toUpsertTeamMemberRequest', () => {
-  it('should convert a valid PokemonInstanceExt to PokemonInstanceWithMeta', () => {
-    const result = PokemonInstanceUtils.toUpsertTeamMemberRequest(mockPokemonInstanceExt)
+  it('should convert a valid PokemonInstance to PokemonInstanceWithMeta', () => {
+    const result = PokemonInstanceUtils.toUpsertTeamMemberRequest(mockPokemonInstance)
     expect(result).toEqual(mockPokemonInstanceWithMeta)
   })
 
   it('should throw an error if ingredient data is corrupt (not exactly 3)', () => {
-    const corruptInstance: PokemonInstanceExt = {
-      ...mockPokemonInstanceExt,
+    const corruptInstance: PokemonInstance = {
+      ...mockPokemonInstance,
       ingredients: [{ level: 0, ingredient: ingredient.BEAN_SAUSAGE, amount: 2 }]
     }
 
@@ -97,7 +97,7 @@ describe('toUpsertTeamMemberRequest', () => {
 
   it('should throw an error if subskill data is corrupt (more than 5)', () => {
     const corruptInstance = {
-      ...mockPokemonInstanceExt,
+      ...mockPokemonInstance,
       subskills: [
         { level: 10, subskill: subskill.HELPING_BONUS },
         { level: 25, subskill: subskill.DREAM_SHARD_BONUS },
@@ -115,27 +115,27 @@ describe('toUpsertTeamMemberRequest', () => {
 })
 
 describe('toPokemonInstanceIdentity', () => {
-  it('should convert a valid PokemonInstanceExt to PokemonInstanceIdentity', () => {
-    const mockPokemonInstanceExt: PokemonInstanceExt = mocks.createMockPokemon()
-    const result = PokemonInstanceUtils.toPokemonInstanceIdentity(mockPokemonInstanceExt)
+  it('should convert a valid PokemonInstance to PokemonInstanceIdentity', () => {
+    const mockPokemonInstance: PokemonInstance = mocks.createMockPokemon()
+    const result = PokemonInstanceUtils.toPokemonInstanceIdentity(mockPokemonInstance)
 
     expect(result).toEqual({
-      pokemon: mockPokemonInstanceExt.pokemon.name,
-      nature: mockPokemonInstanceExt.nature.name,
-      subskills: mockPokemonInstanceExt.subskills.map((subskill) => ({
+      pokemon: mockPokemonInstance.pokemon.name,
+      nature: mockPokemonInstance.nature.name,
+      subskills: mockPokemonInstance.subskills.map((subskill) => ({
         level: subskill.level,
         subskill: subskill.subskill.name
       })),
-      ingredients: mockPokemonInstanceExt.ingredients.map((ingredientSet) => ({
+      ingredients: mockPokemonInstance.ingredients.map((ingredientSet) => ({
         level: ingredientSet.level,
         name: ingredientSet.ingredient.name,
         amount: ingredientSet.amount
       })),
-      carrySize: CarrySizeUtils.baseCarrySize(mockPokemonInstanceExt.pokemon),
-      level: mockPokemonInstanceExt.level,
-      ribbon: mockPokemonInstanceExt.ribbon,
-      skillLevel: mockPokemonInstanceExt.skillLevel,
-      externalId: mockPokemonInstanceExt.externalId,
+      carrySize: CarrySizeUtils.baseCarrySize(mockPokemonInstance.pokemon),
+      level: mockPokemonInstance.level,
+      ribbon: mockPokemonInstance.ribbon,
+      skillLevel: mockPokemonInstance.skillLevel,
+      externalId: mockPokemonInstance.externalId,
       sneakySnacking: false
     })
   })
@@ -196,7 +196,7 @@ describe('createDefaultPokemonInstance', () => {
 describe('createPokemonInstanceWithPreservedAttributes', () => {
   it('should preserve existing attributes while updating Pokemon-specific ones', () => {
     // Create existing Pikachu instance with custom attributes
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       pokemon: PIKACHU,
       level: 45,
       name: 'Custom Name',
@@ -244,7 +244,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
 
   it('should cap skill level to new Pokemon max skill level', () => {
     // Create instance with high skill level
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       skillLevel: 10 // Very high skill level
     })
 
@@ -256,7 +256,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should preserve skill level when within new Pokemon limits', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       skillLevel: 3 // Reasonable skill level
     })
 
@@ -267,7 +267,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should update ingredients to match new Pokemon species', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       pokemon: PIKACHU,
       ingredients: [
         { level: 0, ingredient: ingredient.FANCY_APPLE, amount: 2 },
@@ -288,7 +288,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should update carry size to match new Pokemon species', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       pokemon: PIKACHU,
       carrySize: CarrySizeUtils.baseCarrySize(PIKACHU)
     })
@@ -304,7 +304,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should force shiny to false when the new Pokemon species is shiny-locked', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       pokemon: PIKACHU,
       shiny: true
     })
@@ -315,7 +315,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should preserve shiny when the new Pokemon species is not shiny-locked', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       pokemon: PIKACHU,
       shiny: true
     })
@@ -326,7 +326,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should generate new gender for new Pokemon species', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       gender: 'male'
     })
 
@@ -345,7 +345,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
       { level: 80, subskill: subskill.HELPING_SPEED_S }
     ]
 
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       subskills: complexSubskills
     })
 
@@ -355,7 +355,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should preserve empty subskills array', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       subskills: []
     })
 

--- a/frontend/src/services/utils/pokemon-instance-utils.test.ts
+++ b/frontend/src/services/utils/pokemon-instance-utils.test.ts
@@ -10,30 +10,30 @@ import {
   Ribbon,
   RP,
   subskill,
-  type PokemonInstanceExt,
+  type PokemonInstance,
   type PokemonInstanceWithMeta
 } from 'sleepapi-common'
 import { describe, expect, it } from 'vitest'
 
-const mockPokemonInstanceExt: PokemonInstanceExt = mocks.createMockPokemon({
+const mockPokemonInstance: PokemonInstance = mocks.createMockPokemon({
   subskills: [
     { level: 10, subskill: subskill.HELPING_BONUS },
     { level: 25, subskill: subskill.BERRY_FINDING_S }
   ]
 })
 const mockPokemonInstanceWithMeta: PokemonInstanceWithMeta = {
-  version: mockPokemonInstanceExt.version,
-  saved: mockPokemonInstanceExt.saved,
-  shiny: mockPokemonInstanceExt.shiny,
-  gender: mockPokemonInstanceExt.gender,
-  externalId: mockPokemonInstanceExt.externalId,
-  pokemon: mockPokemonInstanceExt.pokemon.name,
-  name: mockPokemonInstanceExt.name,
-  level: mockPokemonInstanceExt.level,
-  ribbon: mockPokemonInstanceExt.ribbon,
-  carrySize: CarrySizeUtils.baseCarrySize(mockPokemonInstanceExt.pokemon),
-  skillLevel: mockPokemonInstanceExt.skillLevel,
-  nature: mockPokemonInstanceExt.nature.name,
+  version: mockPokemonInstance.version,
+  saved: mockPokemonInstance.saved,
+  shiny: mockPokemonInstance.shiny,
+  gender: mockPokemonInstance.gender,
+  externalId: mockPokemonInstance.externalId,
+  pokemon: mockPokemonInstance.pokemon.name,
+  name: mockPokemonInstance.name,
+  level: mockPokemonInstance.level,
+  ribbon: mockPokemonInstance.ribbon,
+  carrySize: CarrySizeUtils.baseCarrySize(mockPokemonInstance.pokemon),
+  skillLevel: mockPokemonInstance.skillLevel,
+  nature: mockPokemonInstance.nature.name,
   subskills: [
     { level: 10, subskill: 'Helping Bonus' },
     { level: 25, subskill: 'Berry Finding S' }
@@ -46,10 +46,10 @@ const mockPokemonInstanceWithMeta: PokemonInstanceWithMeta = {
   sneakySnacking: false
 }
 
-describe('toPokemonInstanceExt', () => {
-  it('should convert a valid PokemonInstanceWithMeta to PokemonInstanceExt', () => {
-    const result = PokemonInstanceUtils.toPokemonInstanceExt(mockPokemonInstanceWithMeta)
-    expect(result).toEqual({ ...mockPokemonInstanceExt, rp: 834 })
+describe('toPokemonInstance', () => {
+  it('should convert a valid PokemonInstanceWithMeta to PokemonInstance', () => {
+    const result = PokemonInstanceUtils.toPokemonInstance(mockPokemonInstanceWithMeta)
+    expect(result).toEqual({ ...mockPokemonInstance, rp: 834 })
   })
 
   it('should throw an error if ingredient data is corrupt (not exactly 3)', () => {
@@ -58,7 +58,7 @@ describe('toPokemonInstanceExt', () => {
       ingredients: [{ level: 0, name: 'incorrect', amount: 2 }]
     }
 
-    expect(() => PokemonInstanceUtils.toPokemonInstanceExt(corruptInstance)).toThrow('Received corrupt ingredient data')
+    expect(() => PokemonInstanceUtils.toPokemonInstance(corruptInstance)).toThrow('Received corrupt ingredient data')
   })
 
   it('should throw an error if subskill data is corrupt (more than 5)', () => {
@@ -74,19 +74,19 @@ describe('toPokemonInstanceExt', () => {
       ]
     }
 
-    expect(() => PokemonInstanceUtils.toPokemonInstanceExt(corruptInstance)).toThrow('Received corrupt subskill data')
+    expect(() => PokemonInstanceUtils.toPokemonInstance(corruptInstance)).toThrow('Received corrupt subskill data')
   })
 })
 
 describe('toUpsertTeamMemberRequest', () => {
-  it('should convert a valid PokemonInstanceExt to PokemonInstanceWithMeta', () => {
-    const result = PokemonInstanceUtils.toUpsertTeamMemberRequest(mockPokemonInstanceExt)
+  it('should convert a valid PokemonInstance to PokemonInstanceWithMeta', () => {
+    const result = PokemonInstanceUtils.toUpsertTeamMemberRequest(mockPokemonInstance)
     expect(result).toEqual(mockPokemonInstanceWithMeta)
   })
 
   it('should throw an error if ingredient data is corrupt (not exactly 3)', () => {
-    const corruptInstance: PokemonInstanceExt = {
-      ...mockPokemonInstanceExt,
+    const corruptInstance: PokemonInstance = {
+      ...mockPokemonInstance,
       ingredients: [{ level: 0, ingredient: ingredient.BEAN_SAUSAGE, amount: 2 }]
     }
 
@@ -97,7 +97,7 @@ describe('toUpsertTeamMemberRequest', () => {
 
   it('should throw an error if subskill data is corrupt (more than 5)', () => {
     const corruptInstance = {
-      ...mockPokemonInstanceExt,
+      ...mockPokemonInstance,
       subskills: [
         { level: 10, subskill: subskill.HELPING_BONUS },
         { level: 25, subskill: subskill.DREAM_SHARD_BONUS },
@@ -115,27 +115,27 @@ describe('toUpsertTeamMemberRequest', () => {
 })
 
 describe('toPokemonInstanceIdentity', () => {
-  it('should convert a valid PokemonInstanceExt to PokemonInstanceIdentity', () => {
-    const mockPokemonInstanceExt: PokemonInstanceExt = mocks.createMockPokemon()
-    const result = PokemonInstanceUtils.toPokemonInstanceIdentity(mockPokemonInstanceExt)
+  it('should convert a valid PokemonInstance to PokemonInstanceIdentity', () => {
+    const mockPokemonInstance: PokemonInstance = mocks.createMockPokemon()
+    const result = PokemonInstanceUtils.toPokemonInstanceIdentity(mockPokemonInstance)
 
     expect(result).toEqual({
-      pokemon: mockPokemonInstanceExt.pokemon.name,
-      nature: mockPokemonInstanceExt.nature.name,
-      subskills: mockPokemonInstanceExt.subskills.map((subskill) => ({
+      pokemon: mockPokemonInstance.pokemon.name,
+      nature: mockPokemonInstance.nature.name,
+      subskills: mockPokemonInstance.subskills.map((subskill) => ({
         level: subskill.level,
         subskill: subskill.subskill.name
       })),
-      ingredients: mockPokemonInstanceExt.ingredients.map((ingredientSet) => ({
+      ingredients: mockPokemonInstance.ingredients.map((ingredientSet) => ({
         level: ingredientSet.level,
         name: ingredientSet.ingredient.name,
         amount: ingredientSet.amount
       })),
-      carrySize: CarrySizeUtils.baseCarrySize(mockPokemonInstanceExt.pokemon),
-      level: mockPokemonInstanceExt.level,
-      ribbon: mockPokemonInstanceExt.ribbon,
-      skillLevel: mockPokemonInstanceExt.skillLevel,
-      externalId: mockPokemonInstanceExt.externalId,
+      carrySize: CarrySizeUtils.baseCarrySize(mockPokemonInstance.pokemon),
+      level: mockPokemonInstance.level,
+      ribbon: mockPokemonInstance.ribbon,
+      skillLevel: mockPokemonInstance.skillLevel,
+      externalId: mockPokemonInstance.externalId,
       sneakySnacking: false
     })
   })
@@ -196,7 +196,7 @@ describe('createDefaultPokemonInstance', () => {
 describe('createPokemonInstanceWithPreservedAttributes', () => {
   it('should preserve existing attributes while updating Pokemon-specific ones', () => {
     // Create existing Pikachu instance with custom attributes
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       pokemon: PIKACHU,
       level: 45,
       name: 'Custom Name',
@@ -244,7 +244,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
 
   it('should cap skill level to new Pokemon max skill level', () => {
     // Create instance with high skill level
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       skillLevel: 10 // Very high skill level
     })
 
@@ -256,7 +256,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should preserve skill level when within new Pokemon limits', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       skillLevel: 3 // Reasonable skill level
     })
 
@@ -267,7 +267,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should update ingredients to match new Pokemon species', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       pokemon: PIKACHU,
       ingredients: [
         { level: 0, ingredient: ingredient.FANCY_APPLE, amount: 2 },
@@ -288,7 +288,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should update carry size to match new Pokemon species', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       pokemon: PIKACHU,
       carrySize: CarrySizeUtils.baseCarrySize(PIKACHU)
     })
@@ -304,7 +304,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should force shiny to false when the new Pokemon species is shiny-locked', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       pokemon: PIKACHU,
       shiny: true
     })
@@ -318,7 +318,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should preserve shiny when the new Pokemon species is not shiny-locked', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       pokemon: PIKACHU,
       shiny: true
     })
@@ -329,7 +329,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should generate new gender for new Pokemon species', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       gender: 'male'
     })
 
@@ -348,7 +348,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
       { level: 80, subskill: subskill.HELPING_SPEED_S }
     ]
 
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       subskills: complexSubskills
     })
 
@@ -358,7 +358,7 @@ describe('createPokemonInstanceWithPreservedAttributes', () => {
   })
 
   it('should preserve empty subskills array', () => {
-    const existingInstance: PokemonInstanceExt = mocks.createMockPokemon({
+    const existingInstance: PokemonInstance = mocks.createMockPokemon({
       subskills: []
     })
 

--- a/frontend/src/services/utils/pokemon-instance-utils.ts
+++ b/frontend/src/services/utils/pokemon-instance-utils.ts
@@ -11,14 +11,14 @@ import {
   RP,
   uuid,
   type Pokemon,
-  type PokemonInstanceExt,
+  type PokemonInstance,
   type PokemonInstanceIdentity,
   type PokemonInstanceWithMeta,
   type PokemonInstanceWithoutRP
 } from 'sleepapi-common'
 
 class PokemonInstanceUtilsImpl {
-  public createDefaultPokemonInstance(pokemon: Pokemon, attrs?: Partial<PokemonInstanceExt>): PokemonInstanceExt {
+  public createDefaultPokemonInstance(pokemon: Pokemon, attrs?: Partial<PokemonInstance>): PokemonInstance {
     const gender = attrs?.gender ?? getRandomGender(pokemon)
     const instance = {
       carrySize: CarrySizeUtils.baseCarrySize(pokemon),
@@ -53,8 +53,8 @@ class PokemonInstanceUtilsImpl {
 
   public createPokemonInstanceWithPreservedAttributes(
     newPokemon: Pokemon,
-    existingInstance: PokemonInstanceExt
-  ): PokemonInstanceExt {
+    existingInstance: PokemonInstance
+  ): PokemonInstance {
     const instance = {
       ...existingInstance,
       pokemon: newPokemon,
@@ -76,7 +76,7 @@ class PokemonInstanceUtilsImpl {
     }
   }
 
-  public toPokemonInstanceExt(pokemonInstance: PokemonInstanceWithMeta): PokemonInstanceExt {
+  public toPokemonInstance(pokemonInstance: PokemonInstanceWithMeta): PokemonInstance {
     if (pokemonInstance.ingredients.length !== 3) {
       throw new Error('Received corrupt ingredient data')
     } else if (pokemonInstance.subskills.length > 5) {
@@ -114,7 +114,7 @@ class PokemonInstanceUtilsImpl {
     }
   }
 
-  public toUpsertTeamMemberRequest(instancedPokemon: PokemonInstanceExt): PokemonInstanceWithMeta {
+  public toUpsertTeamMemberRequest(instancedPokemon: PokemonInstance): PokemonInstanceWithMeta {
     if (instancedPokemon.ingredients.length !== 3) {
       throw new Error('Received corrupt ingredient data')
     } else if (instancedPokemon.subskills.length > 5) {
@@ -147,7 +147,7 @@ class PokemonInstanceUtilsImpl {
     }
   }
 
-  public toPokemonInstanceIdentity(pokemonInstance: PokemonInstanceExt): PokemonInstanceIdentity {
+  public toPokemonInstanceIdentity(pokemonInstance: PokemonInstance): PokemonInstanceIdentity {
     return {
       pokemon: pokemonInstance.pokemon.name,
       nature: pokemonInstance.nature.name,

--- a/frontend/src/stores/dialog-store/dialog-store.ts
+++ b/frontend/src/stores/dialog-store/dialog-store.ts
@@ -1,16 +1,16 @@
 import { defineStore } from 'pinia'
-import type { PokemonInstanceExt } from 'sleepapi-common'
+import type { PokemonInstance } from 'sleepapi-common'
 import { ref } from 'vue'
 
 export const useDialogStore = defineStore('dialog', () => {
   // ==================== POKEMON SEARCH DIALOG ====================
   const pokemonSearchDialog = ref(false)
-  const pokemonSearchCallback = ref<((pokemonInstance: PokemonInstanceExt) => void) | null>(null)
-  const pokemonSearchCurrentInstance = ref<PokemonInstanceExt | null>(null)
+  const pokemonSearchCallback = ref<((pokemonInstance: PokemonInstance) => void) | null>(null)
+  const pokemonSearchCurrentInstance = ref<PokemonInstance | null>(null)
 
   const openPokemonSearch = (
-    callback: (pokemonInstance: PokemonInstanceExt) => void,
-    currentInstance?: PokemonInstanceExt
+    callback: (pokemonInstance: PokemonInstance) => void,
+    currentInstance?: PokemonInstance
   ) => {
     pokemonSearchCallback.value = callback
     pokemonSearchCurrentInstance.value = currentInstance || null
@@ -23,7 +23,7 @@ export const useDialogStore = defineStore('dialog', () => {
     pokemonSearchCurrentInstance.value = null
   }
 
-  const handlePokemonSelected = (pokemonInstance: PokemonInstanceExt) => {
+  const handlePokemonSelected = (pokemonInstance: PokemonInstance) => {
     if (pokemonSearchCallback.value) {
       pokemonSearchCallback.value(pokemonInstance)
     }
@@ -32,14 +32,14 @@ export const useDialogStore = defineStore('dialog', () => {
 
   // ==================== POKEMON INPUT DIALOG ====================
   const pokemonInputDialog = ref(false)
-  const pokemonInputCallback = ref<((pokemon: PokemonInstanceExt) => void) | null>(null)
-  const pokemonInputProps = ref<{ preSelectedPokemonInstance: PokemonInstanceExt | null }>({
+  const pokemonInputCallback = ref<((pokemon: PokemonInstance) => void) | null>(null)
+  const pokemonInputProps = ref<{ preSelectedPokemonInstance: PokemonInstance | null }>({
     preSelectedPokemonInstance: null
   })
 
   const openPokemonInput = (
-    callback: (pokemon: PokemonInstanceExt) => void,
-    preSelectedPokemonInstance: PokemonInstanceExt
+    callback: (pokemon: PokemonInstance) => void,
+    preSelectedPokemonInstance: PokemonInstance
   ) => {
     pokemonInputCallback.value = callback
     pokemonInputProps.value = { preSelectedPokemonInstance }
@@ -52,7 +52,7 @@ export const useDialogStore = defineStore('dialog', () => {
     pokemonInputProps.value = { preSelectedPokemonInstance: null }
   }
 
-  const savePokemonInput = (pokemon: PokemonInstanceExt) => {
+  const savePokemonInput = (pokemon: PokemonInstance) => {
     if (pokemonInputCallback.value) {
       pokemonInputCallback.value(pokemon)
     }
@@ -62,9 +62,9 @@ export const useDialogStore = defineStore('dialog', () => {
   // ==================== FILLED SLOT DIALOG ====================
   const filledSlotDialog = ref(false)
   const filledSlotProps = ref<{
-    pokemon: PokemonInstanceExt | null
+    pokemon: PokemonInstance | null
     fullTeam: boolean
-    onUpdate?: (pokemon: PokemonInstanceExt) => void
+    onUpdate?: (pokemon: PokemonInstance) => void
     onDuplicate?: () => void
     onToggleSaved?: (state: boolean) => void
     onRemove?: () => void
@@ -74,10 +74,10 @@ export const useDialogStore = defineStore('dialog', () => {
   })
 
   const openFilledSlot = (
-    pokemon: PokemonInstanceExt,
+    pokemon: PokemonInstance,
     fullTeam: boolean,
     callbacks: {
-      onUpdate?: (pokemonInstance: PokemonInstanceExt) => void
+      onUpdate?: (pokemonInstance: PokemonInstance) => void
       onDuplicate?: () => void
       onToggleSaved?: (state: boolean) => void
       onRemove?: () => void

--- a/frontend/src/stores/pokemon/pokemon-store.ts
+++ b/frontend/src/stores/pokemon/pokemon-store.ts
@@ -3,10 +3,10 @@ import { useComparisonStore } from '@/stores/comparison-store/comparison-store'
 import { useTeamStore } from '@/stores/team/team-store'
 import { useUserStore } from '@/stores/user-store'
 import { defineStore } from 'pinia'
-import { DOMAIN_VERSION, getPokemon, type PokemonInstanceExt } from 'sleepapi-common'
+import { DOMAIN_VERSION, getPokemon, type PokemonInstance } from 'sleepapi-common'
 
 export interface PokemonState {
-  pokemon: Record<string, PokemonInstanceExt>
+  pokemon: Record<string, PokemonInstance>
   domainVersion: number
 }
 
@@ -46,7 +46,7 @@ export const usePokemonStore = defineStore('pokemon', {
         this.domainVersion = DOMAIN_VERSION
       }
     },
-    upsertLocalPokemon(pokemon: PokemonInstanceExt) {
+    upsertLocalPokemon(pokemon: PokemonInstance) {
       this.pokemon[pokemon.externalId] = pokemon
     },
     removePokemon(externalId: string, source: 'team' | 'compare' | 'pokebox') {
@@ -74,7 +74,7 @@ export const usePokemonStore = defineStore('pokemon', {
         delete this.pokemon[externalId]
       }
     },
-    upsertServerPokemon(pokemon: PokemonInstanceExt) {
+    upsertServerPokemon(pokemon: PokemonInstance) {
       const userStore = useUserStore()
 
       if (userStore.loggedIn) {

--- a/frontend/src/stores/team/team-store.test.ts
+++ b/frontend/src/stores/team/team-store.test.ts
@@ -6,16 +6,7 @@ import type { PerformanceDetails, TeamInstance } from '@/types/member/instanced'
 import { mocks } from '@/vitest'
 import { createMockTeams } from '@/vitest/mocks/calculator/team-instance'
 import { createMockTeamData } from '@/vitest/mocks/team-data'
-import {
-  berry,
-  commonMocks,
-  LEAFEON,
-  Logger,
-  subskill,
-  uuid,
-  WIGGLYTUFF,
-  type PokemonInstanceExt
-} from 'sleepapi-common'
+import { berry, commonMocks, LEAFEON, Logger, subskill, uuid, WIGGLYTUFF, type PokemonInstance } from 'sleepapi-common'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
@@ -274,7 +265,7 @@ describe('Team Store', () => {
   it('should get number of members in team', async () => {
     const teamStore = useTeamStore()
 
-    const member = { name: 'Pikachu' } as PokemonInstanceExt
+    const member = { name: 'Pikachu' } as PokemonInstance
     teamStore.teams = [
       {
         index: 0,

--- a/frontend/src/stores/team/team-store.ts
+++ b/frontend/src/stores/team/team-store.ts
@@ -4,7 +4,7 @@ import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useUserStore } from '@/stores/user-store'
 import {
   MAX_TEAMS,
-  type MemberProductionExt,
+  type MemberWithProduction,
   type PerformanceDetails,
   type TeamInstance
 } from '@/types/member/instanced'
@@ -26,10 +26,10 @@ import {
   type BerrySetSimple,
   type IngredientSetSimple,
   type IslandInstance,
-  type PokemonInstanceExt,
+  type PokemonInstance,
   type RecipeType,
   type TeamAreaDTO,
-  type TeamSettings
+  type TeamSettingsDto
 } from 'sleepapi-common'
 
 export interface TeamState {
@@ -105,7 +105,7 @@ export const useTeamStore = defineStore('team', {
       const pokemonStore = usePokemonStore()
 
       const currentTeam = state.teams[state.currentIndex]
-      const result: (MemberProductionExt | undefined)[] = []
+      const result: (MemberWithProduction | undefined)[] = []
       for (const memberId of currentTeam.members) {
         const memberInstance = memberId && pokemonStore.getPokemon(memberId)
         const production = currentTeam.production?.members.find((member) => member.externalId === memberId)
@@ -316,7 +316,7 @@ export const useTeamStore = defineStore('team', {
         }
       }
     },
-    async updateTeamMember(updatedMember: PokemonInstanceExt, memberIndex: number, calculateProduction = true) {
+    async updateTeamMember(updatedMember: PokemonInstance, memberIndex: number, calculateProduction = true) {
       this.loadingMembers[memberIndex] = true
 
       const userStore = useUserStore()
@@ -363,14 +363,14 @@ export const useTeamStore = defineStore('team', {
       const pokemonStore = usePokemonStore()
       this.loadingTeams = true
 
-      const members: PokemonInstanceExt[] = []
+      const members: PokemonInstance[] = []
       for (const member of this.teams[teamIndex].members) {
         if (member) {
           const pokemon = pokemonStore.getPokemon(member)
           pokemon && members.push(pokemon)
         }
       }
-      const settings: TeamSettings = {
+      const settings: TeamSettingsDto = {
         camp: this.teams[teamIndex].camp,
         bedtime: this.teams[teamIndex].bedtime,
         wakeup: this.teams[teamIndex].wakeup,
@@ -395,7 +395,7 @@ export const useTeamStore = defineStore('team', {
       }
       this.loadingMembers[openSlotIndex] = true
 
-      const duplicatedMember: PokemonInstanceExt = {
+      const duplicatedMember: PokemonInstance = {
         ...existingMember,
         version: 0,
         saved: false,
@@ -483,7 +483,7 @@ export const useTeamStore = defineStore('team', {
     resetCurrentTeamIvs() {
       this.getCurrentTeam.memberIvs = {}
     },
-    isSupportMember(member: PokemonInstanceExt) {
+    isSupportMember(member: PokemonInstance) {
       const hbOrErb = member.subskills.some(
         (s) =>
           (s.subskill.name.toLowerCase() === subskill.ENERGY_RECOVERY_BONUS.name.toLowerCase() ||

--- a/frontend/src/types/member/instanced.ts
+++ b/frontend/src/types/member/instanced.ts
@@ -6,7 +6,7 @@ import type {
   IngredientSetSimple,
   IslandInstance,
   MemberProduction,
-  PokemonInstanceExt,
+  PokemonInstance,
   RecipeType
 } from 'sleepapi-common'
 
@@ -22,13 +22,13 @@ export interface PerformanceDetails {
   ingredient: number
 }
 
-export interface MemberProductionExt {
-  member: PokemonInstanceExt
+export interface MemberWithProduction {
+  member: PokemonInstance
   production: MemberProduction
   iv?: PerformanceDetails
 }
 
-export interface TeamProductionExt {
+export interface TeamProduction {
   team: TeamCombinedProduction
   members: MemberProduction[]
 }
@@ -46,7 +46,7 @@ export interface TeamInstance {
   version: number
   members: (string | undefined)[]
   memberIvs: Record<string, PerformanceDetails | undefined>
-  production?: TeamProductionExt
+  production?: TeamProduction
 }
 
 export const MAX_TEAMS = 10

--- a/frontend/src/types/team/team-data.ts
+++ b/frontend/src/types/team/team-data.ts
@@ -1,6 +1,6 @@
 import type { TeamInstance } from '@/types/member/instanced'
-import type { PokemonInstanceExt } from 'sleepapi-common'
+import type { PokemonInstance } from 'sleepapi-common'
 
 export interface TeamData extends Omit<TeamInstance, 'members'> {
-  members: PokemonInstanceExt[]
+  members: PokemonInstance[]
 }

--- a/frontend/src/vitest/mocks/calculator/member-production.ts
+++ b/frontend/src/vitest/mocks/calculator/member-production.ts
@@ -1,4 +1,4 @@
-import type { MemberProductionExt } from '@/types/member/instanced'
+import type { MemberWithProduction } from '@/types/member/instanced'
 import { createMockMemberIv } from '@/vitest/mocks/member-iv'
 import { createMockPokemon } from '@/vitest/mocks/pokemon-instance'
 import {
@@ -116,7 +116,7 @@ export function createMockMemberProduction(attrs?: Partial<MemberProduction>): M
   }
 }
 
-export function createMockMemberProductionExt(attrs?: Partial<MemberProductionExt>): MemberProductionExt {
+export function createMockMemberWithProduction(attrs?: Partial<MemberWithProduction>): MemberWithProduction {
   const mockPokemon = createMockPokemon()
   const member = attrs?.member ?? mockPokemon
 

--- a/frontend/src/vitest/mocks/calculator/team-production.ts
+++ b/frontend/src/vitest/mocks/calculator/team-production.ts
@@ -1,16 +1,16 @@
-import type { TeamProductionExt } from '@/types/member/instanced'
-import { createMockMemberProductionExt } from '@/vitest/mocks/calculator/member-production'
+import type { TeamProduction } from '@/types/member/instanced'
+import { createMockMemberWithProduction } from '@/vitest/mocks/calculator/member-production'
 import { mockCookingResult } from '@/vitest/mocks/calculator/mock-cooking-result'
 import { berry, ingredient } from 'sleepapi-common'
 
-export function createMockTeamProduction(attrs?: Partial<TeamProductionExt>): TeamProductionExt {
+export function createMockTeamProduction(attrs?: Partial<TeamProduction>): TeamProduction {
   return {
     team: {
       cooking: mockCookingResult(),
       berries: [{ amount: 10, berry: berry.BELUE, level: 60 }],
       ingredients: [{ amount: 10, ingredient: ingredient.FANCY_APPLE }]
     },
-    members: [createMockMemberProductionExt().production],
+    members: [createMockMemberWithProduction().production],
     ...attrs
   }
 }

--- a/frontend/src/vitest/mocks/pokemon-instance.ts
+++ b/frontend/src/vitest/mocks/pokemon-instance.ts
@@ -1,6 +1,6 @@
-import { CarrySizeUtils, ingredient, nature, PIKACHU, type PokemonInstanceExt } from 'sleepapi-common'
+import { CarrySizeUtils, ingredient, nature, PIKACHU, type PokemonInstance } from 'sleepapi-common'
 
-export function createMockPokemon(attrs?: Partial<PokemonInstanceExt>): PokemonInstanceExt {
+export function createMockPokemon(attrs?: Partial<PokemonInstance>): PokemonInstance {
   return {
     name: 'Bubbles',
     externalId: 'external-id',


### PR DESCRIPTION
When we have paired types with one type intended for data transfer, we sometimes name them `Foo` and `FooDto` (with "Dto" short for "data transfer object), and we sometimes name them `FooExt` and `Foo` (with "Ext" short for "extension"). Our new preference is to use `FooDto` rather than `FooExt`.

This moves everything to the `Foo`-`FooDto` model for consistency. There are a still a small number of types that are intended as data transfer objects but don't have a `Dto` suffix, because there was no paired type. A future refactor can add that suffix to those classes.