### PR TITLE
refactor: make constants for expert bonuses

### DIFF
--- a/common/src/events/events/2025-08-11-greengrass-expert-mode.ts
+++ b/common/src/events/events/2025-08-11-greengrass-expert-mode.ts
@@ -1,4 +1,11 @@
-import type { ExpertModeSettings, TeamMemberExt } from '../../types';
+import {
+  EXPERT_MODE_MAIN_SKILL_LEVEL_BONUS,
+  EXPERT_MODE_SKILL_PERCENT_BONUS,
+  GGEX_MAIN_FREQUENCY_BUFF,
+  GGEX_OFF_FREQUENCY_NERF,
+  type ExpertModeSettings,
+  type TeamMemberExt
+} from '../../types';
 import { EventBuilder } from '../builders/event-builder';
 
 function isMainBerry(input: ExpertModeSettings, member: TeamMemberExt) {
@@ -17,25 +24,25 @@ export const greengrassExpertMode = EventBuilder.create<ExpertModeSettings>()
   .forTeam((input, member) => ({
     'pokemonWithIngredients.pokemon.frequency': (freq) => {
       if (isMainBerry(input, member)) {
-        return freq * 0.9;
+        return freq * (1 - GGEX_MAIN_FREQUENCY_BUFF / 100);
       }
       if (isFavoredBerry(input, member)) {
         return freq;
       }
-      return freq * 1.15;
+      return freq * (1 + GGEX_OFF_FREQUENCY_NERF / 100);
     },
 
     'settings.skillLevel': (level) => {
       if (isMainBerry(input, member)) {
         const maxLevel = member.pokemonWithIngredients.pokemon.skill.maxLevel;
-        return Math.min(level + 1, maxLevel);
+        return Math.min(level + EXPERT_MODE_MAIN_SKILL_LEVEL_BONUS, maxLevel);
       }
       return level;
     },
 
     'pokemonWithIngredients.pokemon.skillPercentage': (percentage) => {
       if (isFavoredBerry(input, member) && input.randomBonus === 'skill') {
-        return percentage * 1.25;
+        return percentage * (1 + EXPERT_MODE_SKILL_PERCENT_BONUS / 100);
       }
       return percentage;
     }

--- a/common/src/events/events/2026-08-06-cyan-expert-mode.ts
+++ b/common/src/events/events/2026-08-06-cyan-expert-mode.ts
@@ -1,4 +1,12 @@
-import type { ExpertModeSettings, TeamMemberExt } from '../../types';
+import {
+  CBEX_MAIN_FREQUENCY_BUFF,
+  CBEX_MAIN_INV_BUFF,
+  CBEX_OFF_FREQUENCY_NERF,
+  EXPERT_MODE_MAIN_SKILL_LEVEL_BONUS,
+  EXPERT_MODE_SKILL_PERCENT_BONUS,
+  type ExpertModeSettings,
+  type TeamMemberExt
+} from '../../types';
 import { EventBuilder } from '../builders/event-builder';
 
 function isMainBerry(input: ExpertModeSettings, member: TeamMemberExt) {
@@ -17,17 +25,17 @@ export const cyanExpertMode = EventBuilder.create<ExpertModeSettings>()
   .forTeam((input, member) => ({
     'pokemonWithIngredients.pokemon.frequency': (freq) => {
       if (isMainBerry(input, member)) {
-        return freq * 0.8;
+        return freq * (1 - CBEX_MAIN_FREQUENCY_BUFF / 100);
       }
       if (isFavoredBerry(input, member)) {
         return freq;
       }
-      return freq * 1.35;
+      return freq * (1 + CBEX_OFF_FREQUENCY_NERF / 100);
     },
 
     'pokemonWithIngredients.pokemon.carrySize': (carry) => {
       if (isMainBerry(input, member)) {
-        return carry + 5;
+        return carry + CBEX_MAIN_INV_BUFF;
       }
       return carry;
     },
@@ -35,14 +43,14 @@ export const cyanExpertMode = EventBuilder.create<ExpertModeSettings>()
     'settings.skillLevel': (level) => {
       if (isMainBerry(input, member)) {
         const maxLevel = member.pokemonWithIngredients.pokemon.skill.maxLevel;
-        return Math.min(level + 1, maxLevel);
+        return Math.min(level + EXPERT_MODE_MAIN_SKILL_LEVEL_BONUS, maxLevel);
       }
       return level;
     },
 
     'pokemonWithIngredients.pokemon.skillPercentage': (percentage) => {
       if (isFavoredBerry(input, member) && input.randomBonus === 'skill') {
-        return percentage * 1.25;
+        return percentage * (1 + EXPERT_MODE_SKILL_PERCENT_BONUS / 100);
       }
       return percentage;
     }

--- a/common/src/types/constants.ts
+++ b/common/src/types/constants.ts
@@ -28,6 +28,15 @@ export const AVERAGE_WEEKLY_CRIT_MULTIPLIER = 1.171428571;
 // island
 export const MAX_ISLAND_BONUS = 85;
 
+// expert island buffs and nerfs
+export const GGEX_MAIN_FREQUENCY_BUFF = 10; // 10% faster
+export const GGEX_OFF_FREQUENCY_NERF = 15; // 15% slower
+export const CBEX_MAIN_FREQUENCY_BUFF = 20; // 20% faster
+export const CBEX_OFF_FREQUENCY_NERF = 35; // 35% slower
+export const CBEX_MAIN_INV_BUFF = 5; // +5 inventory
+export const EXPERT_MODE_SKILL_PERCENT_BONUS = 25; // +25% skill%
+export const EXPERT_MODE_MAIN_SKILL_LEVEL_BONUS = 1; // +1 skill level
+
 // berries
 export const BASE_FAVORED_BERRY_MULTIPLIER = 2;
 export const EXPERT_MODE_BERRY_BONUS_MULTIPLIER = 2.4;

--- a/frontend/src/components/calculator/results/member-results/island-impact/island-effects.ts
+++ b/frontend/src/components/calculator/results/member-results/island-impact/island-effects.ts
@@ -1,6 +1,13 @@
 import {
   BASE_FAVORED_BERRY_MULTIPLIER,
+  CBEX_MAIN_FREQUENCY_BUFF,
+  CBEX_MAIN_INV_BUFF,
+  CBEX_OFF_FREQUENCY_NERF,
   EXPERT_MODE_BERRY_BONUS_MULTIPLIER,
+  EXPERT_MODE_MAIN_SKILL_LEVEL_BONUS,
+  EXPERT_MODE_SKILL_PERCENT_BONUS,
+  GGEX_MAIN_FREQUENCY_BUFF,
+  GGEX_OFF_FREQUENCY_NERF,
   type IslandShortName
 } from 'sleepapi-common'
 
@@ -19,20 +26,20 @@ export interface ExpertIslandEffectConfig {
 
 export const EXPERT_ISLAND_EFFECTS: Partial<Record<IslandShortName, ExpertIslandEffectConfig>> = {
   GGEX: {
-    mainFavoriteExtraEffects: [expertMainFasterHelps('10%')],
-    unfavoredExtraEffects: [expertUnfavoredSlowerHelps('15%')]
+    mainFavoriteExtraEffects: [expertMainFasterHelps(GGEX_MAIN_FREQUENCY_BUFF)],
+    unfavoredExtraEffects: [expertUnfavoredSlowerHelps(GGEX_OFF_FREQUENCY_NERF)]
   },
   CBEX: {
     mainFavoriteExtraEffects: [
-      expertMainFasterHelps('20%'),
+      expertMainFasterHelps(CBEX_MAIN_FREQUENCY_BUFF),
       {
         icon: 'mdi-bag-personal-outline',
-        value: '+5',
+        value: `+${CBEX_MAIN_INV_BUFF}`,
         valueClass: 'text-help',
         text: 'carry size'
       }
     ],
-    unfavoredExtraEffects: [expertUnfavoredSlowerHelps('35%')]
+    unfavoredExtraEffects: [expertUnfavoredSlowerHelps(CBEX_OFF_FREQUENCY_NERF)]
   }
 }
 
@@ -45,7 +52,7 @@ export const baseFavoriteBerryEffect: IslandEffect = {
 
 export const expertMainFavoriteSkillLevel: IslandEffect = {
   image: '/images/misc/skillproc.png',
-  value: '+1',
+  value: `+${EXPERT_MODE_MAIN_SKILL_LEVEL_BONUS}`,
   valueClass: 'text-skill',
   text: 'main skill level'
 }
@@ -73,24 +80,24 @@ export const expertBerryBonus: IslandEffect = {
 
 export const expertSkillChanceBonus: IslandEffect = {
   image: '/images/misc/skillproc.png',
-  value: '1.25x',
+  value: `1.${EXPERT_MODE_SKILL_PERCENT_BONUS}x`,
   valueClass: 'text-skill',
   text: 'main skill chance'
 }
 
-function expertMainFasterHelps(helpIncrease: string): IslandEffect {
+function expertMainFasterHelps(helpIncrease: number): IslandEffect {
   return {
     image: '/images/mainskill/helps.png',
-    value: helpIncrease,
+    value: `${helpIncrease}%`,
     valueClass: 'text-help',
     text: 'faster helps'
   }
 }
 
-function expertUnfavoredSlowerHelps(helpDecrease: string): IslandEffect {
+function expertUnfavoredSlowerHelps(helpDecrease: number): IslandEffect {
   return {
     image: '/images/mainskill/helps.png',
-    value: helpDecrease,
+    value: `${helpDecrease}%`,
     valueClass: 'text-help',
     text: 'slower helps'
   }


### PR DESCRIPTION
Because we need to use the expert mode buff and nerf numbers both in the `common` events and in the `frontend` island impact component, I'm extracting the numbers into constants in `common` that can be referenced by both.

I think probably the +1 and +1-+2 ingredient buffs should also live here, but I don't want to go hunting through the backend to see where it gets used. If any future expert mode areas change the random berry/ingredient/skill buffs, that will be a good time to do that refactor as well. And also some of the `const` effects in `island-effect.ts` will need to update to be `function`s, similar to what we do for the frequency buffs/nerfs.