### PR TITLE
feat: remove tierlist

### DIFF
--- a/common/src/nav/site-nav-items.ts
+++ b/common/src/nav/site-nav-items.ts
@@ -31,13 +31,13 @@ export const SITE_NAV_ITEMS: readonly SiteNavItem[] = [
     icon: 'mdi-compare-horizontal',
     spa: true
   },
-  {
-    id: 'tierlist',
-    label: 'Tier lists',
-    path: '/tierlist',
-    icon: 'mdi-podium',
-    spa: true
-  },
+  // {
+  //   id: 'tierlist',
+  //   label: 'Tier lists',
+  //   path: '/tierlist',
+  //   icon: 'mdi-podium',
+  //   spa: true
+  // },
   {
     id: 'recipes',
     label: 'Recipes',

--- a/frontend/src/components/referrer-welcome/sleep-api-referrer-welcome-dialog.vue
+++ b/frontend/src/components/referrer-welcome/sleep-api-referrer-welcome-dialog.vue
@@ -25,10 +25,6 @@
             <strong><router-link class="simple" to="/recipes/">Recipes</router-link></strong
             >: browse dishes and set your recipe levels
           </li>
-          <li>
-            <strong><router-link class="simple" to="/tier-lists/">Tier lists</router-link></strong
-            >: just like in Sleep API.
-          </li>
         </ul>
         <p class="text-strength mb-3"><strong>You can optionally log in to save your teams and settings!</strong></p>
         <p class="mb-3">

--- a/frontend/src/pages/about/about-page.vue
+++ b/frontend/src/pages/about/about-page.vue
@@ -10,8 +10,8 @@
           <v-row>
             <v-col cols="12" class="px-6">
               <p class="text-center mb-3">
-                Neroli's Lab is a free, open source toolkit for Pokémon Sleep. We build simulations, calculators, and
-                tier lists to help you get the most out of your team.
+                Neroli's Lab is a free, open source toolkit for Pokémon Sleep. We build simulations and calculators to
+                help you get the most out of your team.
               </p>
               <p class="text-center mb-2">
                 The project is open source and we welcome contributions. Discord is our main channel for communication,

--- a/frontend/src/pages/home-page.test.ts
+++ b/frontend/src/pages/home-page.test.ts
@@ -40,11 +40,6 @@ describe('HomePage.vue', () => {
         title: 'Compare',
         description: 'Compare your Pokémon to each other before deciding on your investments.',
         enabled: true
-      },
-      {
-        title: 'Tier lists',
-        description: 'Cooking tier lists based on millions of simulated recipe solutions.',
-        enabled: true
       }
     ]
 

--- a/frontend/src/pages/home-page.vue
+++ b/frontend/src/pages/home-page.vue
@@ -121,14 +121,6 @@ export default defineComponent({
         icon: 'mdi-compare-horizontal',
         to: '/compare',
         enabled: true
-      },
-      {
-        description: 'Cooking tier lists based on millions of simulated recipe solutions.',
-        title: 'Tier lists',
-        src: '/images/misc/doctor3.png',
-        icon: 'mdi-chart-line',
-        to: '/tierlist',
-        enabled: true
       }
     ]
   })

--- a/frontend/src/router/router.ts
+++ b/frontend/src/router/router.ts
@@ -34,7 +34,6 @@ export enum RouteName {
 const CalculatorPage = () => import('@/pages/calculator-page.vue')
 const ComparisonPage = () => import('@/pages/compare/comparison-page.vue')
 const RecipesPage = () => import('@/pages/recipe/recipes-page.vue')
-const TierlistPage = () => import('@/pages/tierlist/tierlist-page.vue')
 const DishInfographicPage = () => import('@/pages/dish-infographic/dish-infographic-page.vue')
 
 // User
@@ -82,30 +81,6 @@ const router = createRouter({
       path: '/dish-infographic',
       name: 'DishInfographic',
       component: DishInfographicPage
-    },
-    {
-      path: '/tierlist',
-      name: 'Tierlist',
-      component: TierlistPage,
-      beforeEnter: (to, from, next) => {
-        if (to.query.level === undefined || to.query.camp === undefined) {
-          next({
-            name: 'Tierlist',
-            query: {
-              level: to.query.level ?? '60',
-              camp: to.query.camp ?? 'true',
-              ...to.query
-            },
-            replace: true
-          })
-        } else {
-          next()
-        }
-      },
-      props: (route) => ({
-        level: route.query.level ? Number(route.query.level) : undefined,
-        camp: route.query.camp ? route.query.camp === 'true' : undefined
-      })
     },
     {
       path: '/settings',


### PR DESCRIPTION
The current tierlist is based on a model where people don't have any team rotations at all, leaving 5 Pokemon in for the full week. That's definitely not the meta these days, and probably it's not a strategy we want to be advocating for through our tiering.

Remove the links and route to the tierlist page, so that people won't stumble upon it and ask us why we rate so many ABA mons so highly.

I'm a bit undecided on whether to keep the code around. In this PR, I've kept most of it, with the hope of reusing it in the future with reworked tier lists. It adds a bit of maintenance burden when it comes to refactors, but if we wind up reusing the code in the future, I think it will be worth it to keep it updated.