### PR TITLE
feat(compare): separate skill units

### DIFF
--- a/frontend/src/components/compare/compare-overview.vue
+++ b/frontend/src/components/compare/compare-overview.vue
@@ -48,8 +48,13 @@
           </template>
 
           <template #item.ingredients="{ item }">
-            <v-row dense style="flex-wrap: nowrap; overflow-x: auto">
-              <v-col v-for="(ingredient, index) in item.ingredientList" :key="index" class="flex-start" cols="4">
+            <v-row dense style="flex-wrap: nowrap; overflow-x: auto" class="px-4">
+              <v-col
+                v-for="(ingredient, index) in item.ingredientList"
+                :key="index"
+                class="flex-start"
+                :cols="ingColumnSize"
+              >
                 <div class="flex-center flex-column">
                   <v-img
                     :src="ingredientImage(ingredient.name)"
@@ -139,6 +144,12 @@ export default defineComponent({
       }
 
       return production
+    },
+    ingColumnSize() {
+      const maxIngCount = this.members
+        .map((item) => item.ingredientList.length)
+        .reduce((max, curr) => Math.max(max, curr))
+      return Math.floor(12 / maxIngCount)
     }
   },
   methods: {

--- a/frontend/src/components/compare/compare-strength.vue
+++ b/frontend/src/components/compare/compare-strength.vue
@@ -153,17 +153,28 @@
 
           <template #item.skillProcs="{ item }">
             <div class="flex-center">
-              <div v-if="!item.skill.is(Metronome, SkillCopy)">
-                <div class="flex-center">
-                  <v-img :src="mainskillImage(item.pokemon)" height="24" width="24"></v-img>
-                </div>
-                <div v-if="item.energyPerMember">
-                  <div>{{ item.energyPerMember }}</div>
-                </div>
-                <div v-else>
-                  {{ item.skillValue }}
-                </div>
-              </div>
+              <v-row dense style="flex-wrap: nowrap; overflow-x: auto">
+                <v-col
+                  v-for="(skill, index) in item.skillValues"
+                  :key="index"
+                  class="flex-start"
+                  :cols="skillColumnSize"
+                >
+                  <div class="flex-center flex-column">
+                    <v-img
+                      :src="mainskillUnitImage(skill.unit)"
+                      height="24"
+                      width="24"
+                      :alt="skill.unit"
+                      :title="skill.unit"
+                      data-testid="mainskill-unit-image"
+                    ></v-img>
+                    <div class="text-center">
+                      {{ skill.amount }}
+                    </div>
+                  </div>
+                </v-col>
+              </v-row>
             </div>
           </template>
 
@@ -185,7 +196,7 @@
 import { defineComponent } from 'vue'
 
 import StackedBar from '@/components/custom-components/stacked-bar.vue'
-import { mainskillImage, pokemonImage } from '@/services/utils/image-utils'
+import { mainskillUnitImage, pokemonImage } from '@/services/utils/image-utils'
 import { useComparisonStore } from '@/stores/comparison-store/comparison-store'
 import { usePokemonStore } from '@/stores/pokemon/pokemon-store'
 import { useUserStore } from '@/stores/user-store'
@@ -195,13 +206,12 @@ import {
   EnergyForEveryoneS,
   MAX_RECIPE_LEVEL,
   MathUtils,
-  Metronome,
-  SkillCopy,
   compactNumber,
   defaultZero,
   getMaxIngredientBonus,
   getPokemon,
   recipeLevelBonus,
+  type MainskillUnit,
   type MemberProduction
 } from 'sleepapi-common'
 
@@ -216,10 +226,8 @@ export default defineComponent({
       comparisonStore,
       userStore,
       pokemonStore,
-      mainskillImage,
-      pokemonImage,
-      Metronome,
-      SkillCopy
+      mainskillUnitImage,
+      pokemonImage
     }
   },
   data: () => ({
@@ -276,15 +284,16 @@ export default defineComponent({
 
         const skillStrength = this.showSkills ? Math.floor(memberProduction.strength.skill.total * timeWindowFactor) : 0
 
-        // TODO: this feels hacky, we're just summing all skill values, even with completely unrelated units. Doesn't make sense. But we're reworking how compare tool is working anyway, this has always worked suboptimally.
-        let skillValue = 0
-        for (const activation of memberPokemon.skill.getUnits()) {
-          skillValue += this.showSkills
-            ? defaultZero(memberProduction.skillValue[activation]?.amountToSelf) +
-              defaultZero(memberProduction.skillValue[activation]?.amountToTeam)
+        const skillValues: { unit: MainskillUnit; amount: number }[] = []
+        for (const unit of memberPokemon.skill.getUnits()) {
+          const amount = this.showSkills
+            ? defaultZero(memberProduction.skillValue[unit]?.amountToSelf) +
+              defaultZero(memberProduction.skillValue[unit]?.amountToTeam)
             : 0
+          if (amount > 0) {
+            skillValues.push({ unit, amount: MathUtils.round(amount * timeWindowFactor, 1) })
+          }
         }
-        skillValue = MathUtils.round(skillValue * timeWindowFactor, 1)
 
         const total = Math.floor(berryPower + ingredientPower + skillStrength)
 
@@ -300,7 +309,7 @@ export default defineComponent({
           ingredientCompact: compactNumber(ingredientPower),
           skill: memberPokemon.skill,
           skillStrength,
-          skillValue,
+          skillValues,
           skillCompact: skillStrength > 0 ? compactNumber(skillStrength) : '',
           energyPerMember: memberPokemon.skill.hasUnit('energy') ? this.energyPerMember(memberProduction) : 0,
           total,
@@ -327,6 +336,12 @@ export default defineComponent({
         })
       }
       return result
+    },
+    skillColumnSize() {
+      const maxUnitCount = this.members
+        .map((item) => item.skillValues.length)
+        .reduce((max, curr) => Math.max(max, curr))
+      return Math.floor(12 / maxUnitCount)
     }
   },
   methods: {

--- a/frontend/src/services/utils/image-utils.ts
+++ b/frontend/src/services/utils/image-utils.ts
@@ -1,12 +1,40 @@
 import { useAvatarStore } from '@/stores/avatar-store/avatar-store'
 import { useUserStore } from '@/stores/user-store'
-import { HelperBoost, type Berry, type Island, type Pokemon } from 'sleepapi-common'
+import { HelperBoost, type Berry, type Island, type MainskillUnit, type Pokemon } from 'sleepapi-common'
 
 export function mainskillImage(pokemon: Pokemon) {
   if (pokemon.skill.is(HelperBoost)) {
     return `/images/type/${pokemon.berry.type}.png`
   } else {
     return `/images/mainskill/${pokemon.skill.image}.png`
+  }
+}
+
+export function mainskillUnitImage(unit: MainskillUnit) {
+  switch (unit) {
+    case 'berries':
+      return '/images/unit/berry.png'
+    case 'candy':
+      return '/images/misc/candy.png'
+    case 'crit chance':
+      return '/images/unit/crit.png'
+    case 'dream shards':
+      return '/images/unit/shard.png'
+    case 'energy':
+      return '/images/unit/energy.png'
+    case 'helps':
+      return '/images/unit/help.png'
+    case 'ingredients':
+      return '/images/unit/ingredient.png'
+    case 'items':
+      // TODO: replace unit with more specific name. Currently, only Shuckle finds items, so it's okay to always display that item.
+      return '/images/misc/berry-juice.png'
+    case 'pot size':
+      return '/images/unit/pot.png'
+    case 'skill helps':
+      return '/images/unit/help.png'
+    case 'strength':
+      return '/images/unit/strength.png'
   }
 }
 


### PR DESCRIPTION
In the compare strength tab, showing data, we used to sum up all the numbers for every unit a mainskill could produce.

Similar to how we display multiple ingredients in the overview tab, display multiple mainskill units in the strength tab. Also change to displaying unit images rather than mainskill images.

As a bonus, while I was looking into the `cols` field on `v-col`, I made an improvement to better support arbitrary numbers of units/ingredients in the two charts. Previously, mons with ing draw skills that could get more than 3 distinct ingredients would have a scroll bar rather than displaying all the ingredients at once. Now, the columns scale based on the mon with the most distinct ingredients/units.